### PR TITLE
feat: Add missing imposter properties requests and numberOfRequests;

### DIFF
--- a/Sources/MountebankSwift/Common/DateFormatter.swift
+++ b/Sources/MountebankSwift/Common/DateFormatter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+final class DateFormatter {
+    static let shared = DateFormatter()
+
+    static let isoDateFormatter: ISO8601DateFormatter = {
+        let isoDateFormatter = ISO8601DateFormatter()
+        isoDateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        isoDateFormatter.formatOptions = [
+            .withFullDate,
+            .withFullTime,
+            .withDashSeparatorInDate,
+            .withFractionalSeconds,
+        ]
+
+        return isoDateFormatter
+    }()
+
+    func formatToDate(_ isoDateString: String) -> Date {
+        // swiftlint:disable:next force_unwrapping
+        Self.isoDateFormatter.date(from: isoDateString)!
+    }
+
+    func formatFromDate(_ date: Date) -> String {
+        // swiftlint:disable:next force_unwrapping
+        Self.isoDateFormatter.string(from: date)
+    }
+}

--- a/Sources/MountebankSwift/Common/NetworkProtocol.swift
+++ b/Sources/MountebankSwift/Common/NetworkProtocol.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// List of netwerk protocol's MountebankSwift does support.
-///
-/// Mountebank itself does also support `tcp`, `smtp` and custom protocols
+/// Mountebank does also support `tcp`, `smtp` and custom protocols
 /// implemented in community plugins.
+///
+/// Please submit a feature request issue on Github for support if you need other protocols
 public enum NetworkProtocol: String, Codable, Equatable {
     case http
     case https

--- a/Sources/MountebankSwift/Common/NetworkProtocol.swift
+++ b/Sources/MountebankSwift/Common/NetworkProtocol.swift
@@ -1,8 +1,10 @@
 import Foundation
 
+/// List of netwerk protocol's MountebankSwift does support.
+///
+/// Mountebank itself does also support `tcp`, `smtp` and custom protocols
+/// implemented in community plugins.
 public enum NetworkProtocol: String, Codable, Equatable {
     case http
     case https
-    case tcp
-    case smtp
 }

--- a/Sources/MountebankSwift/Common/Request.swift
+++ b/Sources/MountebankSwift/Common/Request.swift
@@ -20,7 +20,7 @@ public struct Request: Equatable, Codable, CustomDebugStringConvertible {
     }
 
     public var debugDescription: String {
-        [method.map { "\($0.rawValue)" }, path]
+        [method.map(\.rawValue), path]
             .compactMap { $0 }
             .joined(separator: " ")
     }

--- a/Sources/MountebankSwift/Models/Config/Logs.Log+Codable.swift
+++ b/Sources/MountebankSwift/Models/Config/Logs.Log+Codable.swift
@@ -13,22 +13,8 @@ extension Logs.Log {
         try container.encode(level, forKey: .level)
         try container.encode(message, forKey: .message)
         if let timestamp {
-            let dateFormatter = Self.makeDateformatter()
-            try container.encodeIfPresent(dateFormatter.string(from: timestamp), forKey: .timestamp)
+            try container.encodeIfPresent(DateFormatter.shared.formatFromDate(timestamp), forKey: .timestamp)
         }
-    }
-
-    private static func makeDateformatter() -> ISO8601DateFormatter {
-        let isoDateFormatter = ISO8601DateFormatter()
-        isoDateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        isoDateFormatter.formatOptions = [
-            .withFullDate,
-            .withFullTime,
-            .withDashSeparatorInDate,
-            .withFractionalSeconds,
-        ]
-
-        return isoDateFormatter
     }
 
     public init(from decoder: Decoder) throws {
@@ -38,8 +24,7 @@ extension Logs.Log {
         message = try container.decode(String.self, forKey: .message)
 
         if let dateString = try container.decodeIfPresent(String.self, forKey: .timestamp) {
-            let formatter = Self.makeDateformatter()
-            timestamp = formatter.date(from: dateString)
+            timestamp = DateFormatter.shared.formatToDate(dateString)
         } else {
             timestamp = nil
         }

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest+Codable.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest+Codable.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+extension Imposter.RecordedRequest {
+    enum CodingKeys: String, CodingKey, Equatable {
+        case method
+        case path
+        case query
+        case headers
+        case body
+        case form
+        case timestamp
+        case requestFrom
+        case ip
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encodeIfPresent(method, forKey: .method)
+        try container.encodeIfPresent(path, forKey: .path)
+        try container.encodeIfPresent(query, forKey: .query)
+        try container.encodeIfPresent(headers, forKey: .headers)
+        try container.encodeIfPresent(body, forKey: .body)
+        try container.encodeIfPresent(form, forKey: .form)
+        try container.encode(DateFormatter.shared.formatFromDate(timestamp), forKey: .timestamp)
+        try container.encode(requestFrom, forKey: .requestFrom)
+        try container.encode(ip, forKey: .ip)
+
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        method = try container.decodeIfPresent(HTTPMethod.self, forKey: .method)
+        path = try container.decodeIfPresent(String.self, forKey: .path)
+        query = try container.decodeIfPresent([String: String].self, forKey: .query)
+
+        headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
+        body = try container.decodeIfPresent(JSON.self, forKey: .body)
+        form = try container.decodeIfPresent(String.self, forKey: .form)
+
+        let timestampString = try container.decode(String.self, forKey: .timestamp)
+        timestamp = DateFormatter.shared.formatToDate(timestampString)
+        requestFrom = try container.decode(String.self, forKey: .requestFrom)
+        ip = try container.decode(String.self, forKey: .ip)
+    }
+
+}

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
@@ -36,7 +36,7 @@ extension Imposter {
         }
 
         public var debugDescription: String {
-            [method.map { "\($0.rawValue)" }, path]
+            [method.map(\.rawValue), path]
                 .compactMap { $0 }
                 .joined(separator: " ")
         }

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension Imposter {
+    public struct RecordedRequest: Equatable, Codable, CustomDebugStringConvertible {
+        public let method: HTTPMethod?
+        public let path: String?
+        public let query: [String: String]?
+        public let headers: [String: String]?
+        public let body: JSON?
+        public let form: String?
+
+        public let timestamp: Date
+        public let requestFrom: String
+        public let ip: String
+
+        init(
+            method: HTTPMethod,
+            path: String,
+            query: [String: String]? = nil,
+            headers: [String: String]? = nil,
+            body: JSON? = nil,
+            form: String? = nil,
+            requestFrom: String,
+            ip: String,
+            timestamp: Date
+        ) {
+            self.method = method
+            self.path = path
+            self.query = query
+            self.headers = headers
+            self.body = body
+            self.form = form
+            self.requestFrom = requestFrom
+            self.ip = ip
+            self.timestamp = timestamp
+        }
+
+        public var debugDescription: String {
+            [method.map { "\($0.rawValue)" }, path]
+                .compactMap { $0 }
+                .joined(separator: " ")
+        }
+    }
+}

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.swift
@@ -35,7 +35,7 @@ public struct Imposter: Codable, Equatable {
     /// Mountebank will save all requests to the imposter for mock verification.
     ///
     /// By retrieving the imposter, your client code can determine if an expected service call was in fact made.
-    public let requests: [JSON]?
+    public let requests: [Imposter.RecordedRequest]?
 
     enum CodingKeys: String, CodingKey {
         case port
@@ -56,7 +56,7 @@ public struct Imposter: Codable, Equatable {
         defaultResponse: Is? = nil,
         recordRequests: Bool? = nil,
         numberOfRequests: Int? = nil,
-        requests: [JSON]? = nil
+        requests: [Imposter.RecordedRequest]? = nil
     ) {
         self.port = port
         self.networkProtocol = networkProtocol

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.swift
@@ -29,9 +29,13 @@ public struct Imposter: Codable, Equatable {
     /// If set to true, the server will record requests received, for mock verification purposes.
     public let recordRequests: Bool?
 
-    // TODO: MB responses containing imposters will could also contain
-    // public let numberOfRequests: Int?
-    // public let requests: [Request]
+    /// The number of requests to this imposter
+    public let numberOfRequests: Int?
+
+    /// Mountebank will save all requests to the imposter for mock verification.
+    ///
+    /// By retrieving the imposter, your client code can determine if an expected service call was in fact made.
+    public let requests: [JSON]?
 
     enum CodingKeys: String, CodingKey {
         case port
@@ -40,6 +44,8 @@ public struct Imposter: Codable, Equatable {
         case stubs
         case recordRequests
         case defaultResponse
+        case numberOfRequests
+        case requests
     }
 
     public init(
@@ -48,7 +54,9 @@ public struct Imposter: Codable, Equatable {
         name: String? = nil,
         stubs: [Stub],
         defaultResponse: Is? = nil,
-        recordRequests: Bool? = nil
+        recordRequests: Bool? = nil,
+        numberOfRequests: Int? = nil,
+        requests: [JSON]? = nil
     ) {
         self.port = port
         self.networkProtocol = networkProtocol
@@ -56,5 +64,7 @@ public struct Imposter: Codable, Equatable {
         self.stubs = stubs
         self.defaultResponse = defaultResponse
         self.recordRequests = recordRequests
+        self.numberOfRequests = numberOfRequests
+        self.requests = requests
     }
 }

--- a/Sources/MountebankSwift/Models/Stub/Response/Proxy.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Proxy.swift
@@ -56,4 +56,4 @@ struct ProxyParameters {
     let passphrase: String?
     /// Key-value pairs of headers to inject into the proxied request.
     let injectHeaders: [String: String]
- }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/StubResponse.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/StubResponse.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 /// Empty protocol for easier usage for the Stub api.
-/// . The following symbols conform: Is, Proxy, Inject and Fault
+/// The following symbols conform: ``Is``, ``Proxy``, ``Inject`` and ``Fault``
 public protocol StubResponse: Codable, Equatable {}

--- a/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
+++ b/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
@@ -36,13 +36,25 @@ final class MountebankIntegrationTests: XCTestCase {
     }
 
     func testPostImposter() async throws {
-        let imposterResult = try await sut.postImposter(imposter: Imposter.Examples.includingAllStubs.value)
+        let imposterToPost = Imposter.Examples.includingAllStubs.value
+        let imposterResult = try await sut.postImposter(imposter: imposterToPost)
         guard imposterResult.port != nil else {
             XCTFail("Port should have been set by now.")
             return
         }
 
-        XCTAssertEqual(imposterResult, Imposter.Examples.includingAllStubs.value)
+        let result = Imposter(
+            port: imposterToPost.port,
+            networkProtocol: imposterToPost.networkProtocol,
+            name: imposterToPost.name,
+            stubs: imposterToPost.stubs,
+            defaultResponse: imposterToPost.defaultResponse,
+            recordRequests: imposterToPost.recordRequests,
+            numberOfRequests: 0,
+            requests: []
+        )
+
+        XCTAssertEqual(imposterResult, result)
     }
 
     func testUpdatingStub() async throws {

--- a/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
+++ b/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
@@ -57,6 +57,23 @@ final class MountebankIntegrationTests: XCTestCase {
         XCTAssertEqual(imposterResult, result)
     }
 
+    func testGetImposter() async throws {
+        let port = try await postDefaultImposter(imposter: Imposter.Examples.simpleRecordRequests.value)
+        let httpClient = HttpClient()
+
+        let path = "/text-200"
+        let request = HTTPRequest(url: sut.makeImposterUrl(port: port).appending(path: path), method: .get)
+
+        _ = try await httpClient.httpRequest(request)
+        _ = try await httpClient.httpRequest(request)
+
+        let imposter = try await sut.getImposter(port: port)
+
+        XCTAssertEqual(imposter.requests?.count, 2)
+        XCTAssertEqual(imposter.requests?.first?.path, path)
+        XCTAssertEqual(imposter.requests?.first?.method, .get)
+    }
+
     func testUpdatingStub() async throws {
         let port = try await postDefaultImposter(imposter: Imposter.Examples.simple.value)
         let updatedImposterResult = try await sut.postImposterStub(
@@ -103,7 +120,7 @@ final class MountebankIntegrationTests: XCTestCase {
             allImposters,
             Imposters(imposters: [
                 Imposters.ImposterRef(networkProtocol: .https, port: port1),
-                Imposters.ImposterRef(networkProtocol: .https, port: port2),
+                Imposters.ImposterRef(networkProtocol: .http, port: port2),
             ])
         )
     }

--- a/Tests/MountebankSwiftTests/Common/DateFormatterTests.swift
+++ b/Tests/MountebankSwiftTests/Common/DateFormatterTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import XCTest
+@testable import MountebankSwift
+
+class DateFormatterTests: XCTestCase {
+
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var sut: MountebankSwift.DateFormatter!
+
+    override func setUp() async throws {
+        sut = DateFormatter()
+    }
+
+    func testFromAndToDate() {
+        let dateString = "2023-12-08T20:09:06.263Z"
+        let dateObject = Date(timeIntervalSince1970: 1702066146.263)
+
+        XCTAssertEqual(sut.formatToDate(dateString), dateObject)
+        XCTAssertEqual(sut.formatFromDate(dateObject), dateString)
+    }
+}

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
@@ -1,20 +1,18 @@
-import MountebankSwift
 import XCTest
+@testable import MountebankSwift
 
 extension Imposter {
     enum Examples {
         static let simple = Example(
             value: Imposter(
                 port: 19190,
-                networkProtocol: .https,
-                stubs: [Stub.Examples.text.value],
-                defaultResponse: Is(statusCode: 403)
+                networkProtocol: .http,
+                stubs: [Stub.Examples.text.value]
             ),
             json: [
                 "port": 19190,
-                "protocol": "https",
+                "protocol": "http",
                 "stubs": [Stub.Examples.text.json],
-                "defaultResponse": ["statusCode": 403],
             ]
         )
 
@@ -65,7 +63,13 @@ extension Imposter {
                 stubs: [Stub.Examples.text.value],
                 recordRequests: true,
                 numberOfRequests: 1,
-                requests: [.object(["ip": "127.0.0.1", "body": "test"])]
+                requests: [Imposter.RecordedRequest(
+                    method: .get,
+                    path: "/test-path",
+                    requestFrom: "127.0.0.1",
+                    ip: "127.0.0.1",
+                    timestamp: Date(timeIntervalSince1970: 1702066146.263)
+                )]
             ),
             json: [
                 "port": 19190,
@@ -75,8 +79,11 @@ extension Imposter {
                 "numberOfRequests": 1,
                 "requests": [
                     [
+                        "method": "GET",
+                        "path": "/test-path",
+                        "requestFrom": "127.0.0.1",
                         "ip": "127.0.0.1",
-                        "body": "test",
+                        "timestamp": "2023-12-08T20:09:06.263Z",
                     ],
                 ],
             ]
@@ -85,7 +92,7 @@ extension Imposter {
         static let includingAllStubs = Example(
             value: Imposter(
                 port: 8080,
-                networkProtocol: .https,
+                networkProtocol: .http,
                 name: "Single stub",
                 stubs: Stub.Examples.all.map(\.value),
                 defaultResponse: Is(statusCode: 403),
@@ -93,12 +100,28 @@ extension Imposter {
             ),
             json: [
                 "port": 8080,
-                "protocol": "https",
+                "protocol": "http",
                 "name": "Single stub",
                 "stubs": .array(Stub.Examples.all.map(\.json)),
                 "defaultResponse": ["statusCode": 403],
                 "recordRequests": true,
             ]
         )
+
+        static let simpleRecordRequests = Example(
+            value: Imposter(
+                port: 19190,
+                networkProtocol: .http,
+                stubs: [Stub.Examples.text.value],
+                recordRequests: true
+            ),
+            json: [
+                "port": 19190,
+                "protocol": "http",
+                "stubs": [Stub.Examples.text.json],
+                "recordRequests": true,
+            ]
+        )
     }
+
 }

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
@@ -58,6 +58,30 @@ extension Imposter {
             ]
         )
 
+        static let withResponseData = Example(
+            value: Imposter(
+                port: 19190,
+                networkProtocol: .https,
+                stubs: [Stub.Examples.text.value],
+                recordRequests: true,
+                numberOfRequests: 1,
+                requests: [.object(["ip": "127.0.0.1", "body": "test"])]
+            ),
+            json: [
+                "port": 19190,
+                "protocol": "https",
+                "stubs": [Stub.Examples.text.json],
+                "recordRequests": true,
+                "numberOfRequests": 1,
+                "requests": [
+                    [
+                        "ip": "127.0.0.1",
+                        "body": "test",
+                    ],
+                ],
+            ]
+        )
+
         static let includingAllStubs = Example(
             value: Imposter(
                 port: 8080,

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter.RecordedRequest+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter.RecordedRequest+Examples.swift
@@ -1,0 +1,48 @@
+import Foundation
+@testable import MountebankSwift
+
+extension Imposter.RecordedRequest {
+    enum Examples {
+        static let simple = Example(
+            value: Imposter.RecordedRequest(
+                method: .get,
+                path: "/200-path",
+                requestFrom: "127.0.0.1",
+                ip: "127.0.0.2",
+                timestamp: Date(timeIntervalSince1970: 1702066146.263)
+            ),
+            json: [
+                "method": "GET",
+                "path": "/200-path",
+                "requestFrom": "127.0.0.1",
+                "ip": "127.0.0.2",
+                "timestamp": "2023-12-08T20:09:06.263Z",
+            ]
+        )
+
+        static let advanced = Example(
+            value: Imposter.RecordedRequest(
+                method: .get,
+                path: "/200-path",
+                query: ["query": "test"],
+                headers: ["Content-Type": "JSON"],
+                body: ["hello"],
+                form: "form input",
+                requestFrom: "127.0.0.1",
+                ip: "127.0.0.2",
+                timestamp: Date(timeIntervalSince1970: 1702066146.263)
+            ),
+            json: [
+                "method": "GET",
+                "path": "/200-path",
+                "query": ["query": "test"],
+                "headers": ["Content-Type": "JSON"],
+                "body": ["hello"],
+                "form": "form input",
+                "requestFrom": "127.0.0.1",
+                "ip": "127.0.0.2",
+                "timestamp": "2023-12-08T20:09:06.263Z",
+            ]
+        )
+    }
+}

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Predicate/Predicate+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Predicate/Predicate+Examples.swift
@@ -34,7 +34,7 @@ extension MountebankSwift.Predicate {
                     "path": "/test-is-200",
                     "query": ["key": ["first", "second"]],
                     "headers": ["foo": "bar"],
-                    "data": ["baz"]
+                    "data": ["baz"],
                 ],
             ]
         )

--- a/Tests/MountebankSwiftTests/Models/ImposterTests.swift
+++ b/Tests/MountebankSwiftTests/Models/ImposterTests.swift
@@ -24,6 +24,17 @@ final class ImposterTests: XCTestCase {
         )
     }
 
+    func testWithResponseData() throws {
+        try assertEncode(
+            Imposter.Examples.withResponseData.value,
+            Imposter.Examples.withResponseData.json
+        )
+        try assertDecode(
+            Imposter.Examples.withResponseData.json,
+            Imposter.Examples.withResponseData.value
+        )
+    }
+
     func testIncludingAllStubs() throws {
         try assertEncode(
             Imposter.Examples.includingAllStubs.value,

--- a/Tests/MountebankSwiftTests/Models/Stub/Imposter.RecordedRequestTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Imposter.RecordedRequestTests.swift
@@ -1,0 +1,28 @@
+import MountebankSwift
+
+import XCTest
+
+final class ImposterRecordedRequestTests: XCTestCase {
+    func testSimpleText() throws {
+        try assertEncode(
+            Imposter.RecordedRequest.Examples.simple.value,
+            Imposter.RecordedRequest.Examples.simple.json
+        )
+        try assertDecode(
+            Imposter.RecordedRequest.Examples.simple.json,
+            Imposter.RecordedRequest.Examples.simple.value
+        )
+    }
+
+    func testAdvancedText() throws {
+        try assertEncode(
+            Imposter.RecordedRequest.Examples.advanced.value,
+            Imposter.RecordedRequest.Examples.advanced.json
+        )
+        try assertDecode(
+            Imposter.RecordedRequest.Examples.advanced.json,
+            Imposter.RecordedRequest.Examples.advanced.value
+        )
+    }
+
+}


### PR DESCRIPTION
Add the missing imposter properties requests and numberOfRequests.

See https://www.mbtest.org/docs/api/contracts?type=imposter for the imposter contract; 

The requests object can't be easy typed, because of the many different kind of requests a imposter can get. The requests object can be typed in the future. This is something we do in the future.

The structure of the different kind of requests can be found here:
- https://github.com/bbyars/mountebank/blob/master/src/models/http/httpRequest.js
- https://github.com/bbyars/mountebank/blob/master/src/models/smtp/smtpRequest.js
- https://github.com/bbyars/mountebank/blob/master/src/models/tcp/tcpRequest.js

There is also a possibility to create your own see for example:
- https://github.com/bashj79/mb-graphql

So the response also needs to be a bit flexible to support other custom responses build by the community.