### PR TITLE
fix: Only run test on newer iOS versions;

### DIFF
--- a/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
+++ b/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
@@ -57,6 +57,7 @@ final class MountebankIntegrationTests: XCTestCase {
         XCTAssertEqual(imposterResult, result)
     }
 
+    @available(iOS 16.0, *)
     func testGetImposter() async throws {
         let imposterPort = try await postDefaultImposter(imposter: Imposter.Examples.simpleRecordRequests.value)
         let httpClient = HttpClient()


### PR DESCRIPTION
The project did not compile on older iOS versions. This does fix that.