### PR TITLE
Add support for custom json date format strategies

### DIFF
--- a/Sources/MountebankSwift/Api/Mountebank.swift
+++ b/Sources/MountebankSwift/Api/Mountebank.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+// Project wide en/decoders
+let jsonDecoder = JSONDecoder()
+let jsonEncoder = JSONEncoder()
+
 /// Mountebank client to connect to the Mountebank stub server.
 ///
 /// The client is used to submit imposters to the Mountebank server.
@@ -32,8 +36,6 @@ public struct Mountebank {
     }
 
     private let httpClient: HttpClientProtocol
-    private let jsonEncoder = JSONEncoder()
-    private let jsonDecoder = JSONDecoder()
 
     /// - Parameters:
     ///   - host: The Mountebank server host address
@@ -381,5 +383,4 @@ public struct Mountebank {
             throw MountebankValidationError.invalidResponseData
         }
     }
-
 }

--- a/Sources/MountebankSwift/Common/JSON.swift
+++ b/Sources/MountebankSwift/Common/JSON.swift
@@ -24,12 +24,11 @@
 
 import Foundation
 
-fileprivate let encoder: JSONEncoder = {
+fileprivate let prettyPrintingJSONEncoder: JSONEncoder = {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
     return encoder
 }()
-fileprivate let decoder = JSONDecoder()
 
 /// A JSON value representation. This is a bit more useful than the naïve `[String:Any]` type
 /// for JSON values, since it makes sure only valid JSON values are present
@@ -95,7 +94,7 @@ public enum JSON: Codable, Hashable {
             return "null"
         default:
             // swiftlint:disable:next force_try force_unwrapping
-            return try! String(data: encoder.encode(self), encoding: .utf8)!
+            return try! String(data: prettyPrintingJSONEncoder.encode(self), encoding: .utf8)!
         }
     }
 }
@@ -250,8 +249,8 @@ extension JSON {
     /// Create a JSON value from an `Encodable`. This will give you access to the “raw”
     /// encoded JSON value the `Encodable` is serialized into.
     public init<T: Encodable>(encodable: T) throws {
-        let encoded = try encoder.encode(encodable)
-        self = try decoder.decode(JSON.self, from: encoded)
+        let encoded = try jsonEncoder.encode(encodable)
+        self = try jsonDecoder.decode(JSON.self, from: encoded)
     }
 }
 

--- a/Sources/MountebankSwift/Common/JSON.swift
+++ b/Sources/MountebankSwift/Common/JSON.swift
@@ -24,6 +24,13 @@
 
 import Foundation
 
+fileprivate let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted]
+    return encoder
+}()
+fileprivate let decoder = JSONDecoder()
+
 /// A JSON value representation. This is a bit more useful than the naïve `[String:Any]` type
 /// for JSON values, since it makes sure only valid JSON values are present
 ///
@@ -87,8 +94,6 @@ public enum JSON: Codable, Hashable {
         case .null:
             return "null"
         default:
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted]
             // swiftlint:disable:next force_try force_unwrapping
             return try! String(data: encoder.encode(self), encoding: .utf8)!
         }
@@ -245,8 +250,8 @@ extension JSON {
     /// Create a JSON value from an `Encodable`. This will give you access to the “raw”
     /// encoded JSON value the `Encodable` is serialized into.
     public init<T: Encodable>(encodable: T) throws {
-        let encoded = try JSONEncoder().encode(encodable)
-        self = try JSONDecoder().decode(JSON.self, from: encoded)
+        let encoded = try encoder.encode(encodable)
+        self = try decoder.decode(JSON.self, from: encoded)
     }
 }
 

--- a/Sources/MountebankSwift/Models/Stub/Response/Body.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Body.swift
@@ -1,12 +1,14 @@
 import Foundation
 
-private var jsonEncoder = JSONEncoder()
-
 /// A body for an ``Is`` response
 public enum Body: Equatable {
     case text(String)
+    /// A JSON body that will be encoded to a text response
     case json(JSON)
-    case jsonEncodable(Encodable)
+    /// An Encodable body that will be encoded to a text response
+    /// Custom encoding strategies are supported by providing a custom JSONEncoder
+    case jsonEncodable(Encodable, JSONEncoder? = nil)
+    /// A Data response that will be base64 encoded
     case data(Data)
 
     public static func == (lhs: Body, rhs: Body) -> Bool {
@@ -17,11 +19,14 @@ public enum Body: Equatable {
             return lhs == rhs
         case (.data(let lhs), .data(let rhs)):
             return lhs == rhs
-        case (.jsonEncodable(let lhs), .jsonEncodable(let rhs)):
+        case (.jsonEncodable(let lhs, let lhsEncoder), .jsonEncodable(let rhs, let rhsEncoder)):
+            guard lhsEncoder === rhsEncoder else {
+                return false
+            }
             do {
-                return try jsonEncoder.encode(lhs) == jsonEncoder.encode(rhs)
+                return try (lhsEncoder ?? jsonEncoder).encode(lhs) == (rhsEncoder ?? jsonEncoder).encode(rhs)
             } catch {
-                print("Failed to decode object: \(error)")
+                print("Failed to encode object: \(error)")
                 return false
             }
         case (.text, _), (.json, _), (.jsonEncodable, _), (.data, _):

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is+Codable.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is+Codable.swift
@@ -34,8 +34,14 @@ extension Is: Codable {
         case .data(let data):
             try container.encode(BodyMode.binary, forKey: .mode)
             try container.encode(data, forKey: .body)
-        case .jsonEncodable(let value):
-            try container.encode(value, forKey: .body)
+        case .jsonEncodable(let value, let customJsonEncoder):
+            if let customJsonEncoder {
+                let data = try customJsonEncoder.encode(value)
+                let json = try jsonDecoder.decode(JSON.self, from: data)
+                try container.encode(json, forKey: .body)
+            } else {
+                try container.encode(value, forKey: .body)
+            }
         }
     }
 

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is+initializers.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is+initializers.swift
@@ -53,12 +53,13 @@ extension Is {
         statusCode: Int = 200,
         headers: [String: String]? = nil,
         body: any Codable,
+        encoder: JSONEncoder? = nil,
         parameters: ResponseParameters? = nil
     ) {
         self.init(
             statusCode: statusCode,
             headers: headers,
-            body: .jsonEncodable(body),
+            body: .jsonEncodable(body, encoder),
             parameters: parameters
         )
     }

--- a/Tests/MountebankSwiftTests/Api/MountebankTests.swift
+++ b/Tests/MountebankSwiftTests/Api/MountebankTests.swift
@@ -7,19 +7,16 @@ class MountebankTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var sut: Mountebank!
     private var httpClientSpy: HttpClientSpy!
-    private var jsonEncoder: JSONEncoder!
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUp() async throws {
         httpClientSpy = HttpClientSpy()
-        jsonEncoder = JSONEncoder()
         sut = Mountebank(host: .localhost, port: 2525, httpClient: httpClientSpy)
     }
 
     override func tearDown() async throws {
         httpClientSpy = nil
         sut = nil
-        jsonEncoder = nil
     }
 
     func testGetImposter() async throws {
@@ -257,6 +254,6 @@ class MountebankTests: XCTestCase {
     }
 
     private func makeDataFromJSON(_ json: JSON) throws -> Data {
-        try jsonEncoder.encode(json)
+        try testEncoder.encode(json)
     }
 }

--- a/Tests/MountebankSwiftTests/ExampleData/SampleFile.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/SampleFile.swift
@@ -31,7 +31,7 @@ enum SampleFile: String {
             return .data(data)
         case .json:
             // swiftlint:disable:next force_try
-            return .json(try! testDecoder.decode(JSON.self, from: data))
+            return .json(try! jsonDecoder.decode(JSON.self, from: data))
         case .txt, .html:
             return .text(string)
         }

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Is+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Is+Examples.swift
@@ -73,6 +73,13 @@ extension Is {
             ]
         )
 
+        static let customJSONEncoder: JSONEncoder = {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+            return encoder
+        }()
+
         static let jsonEncodableCustomDateFormatAndKeyEncodingStrategy = Example(
             value: Is(
                 statusCode: 200,
@@ -82,7 +89,8 @@ extension Is {
                     bar: SomeCodableObject.Bar(
                         dateOfBirth: Date(timeIntervalSinceReferenceDate: 0)
                     )
-                )
+                ),
+                encoder: customJSONEncoder
             ),
             json: [
                 "statusCode": 200,

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Is+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Is+Examples.swift
@@ -43,7 +43,7 @@ extension Is {
 
         struct SomeCodableObject: Codable {
             struct Bar: Codable {
-                let baz: String
+                let dateOfBirth: Date
             }
 
             let foo: String
@@ -54,12 +54,45 @@ extension Is {
             value: Is(
                 statusCode: 200,
                 headers: ["Content-Type": "application/json"],
-                body: SomeCodableObject(foo: "Foo", bar: SomeCodableObject.Bar(baz: "Baz"))
+                body: SomeCodableObject(
+                    foo: "Foo",
+                    bar: SomeCodableObject.Bar(
+                        dateOfBirth: Date(timeIntervalSinceReferenceDate: 10_000_00)
+                    )
+                )
             ),
             json: [
                 "statusCode": 200,
                 "headers": ["Content-Type": "application/json"],
-                "body": ["foo": "Foo", "bar": ["baz": "Baz"]],
+                "body": [
+                    "foo": "Foo",
+                    "bar": [
+                        "dateOfBirth": 1000000
+                    ]
+                ],
+            ]
+        )
+
+        static let jsonEncodableCustomDateFormatAndKeyEncodingStrategy = Example(
+            value: Is(
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"],
+                body: SomeCodableObject(
+                    foo: "Foo",
+                    bar: SomeCodableObject.Bar(
+                        dateOfBirth: Date(timeIntervalSinceReferenceDate: 0)
+                    )
+                )
+            ),
+            json: [
+                "statusCode": 200,
+                "headers": ["Content-Type": "application/json"],
+                "body": [
+                    "foo": "Foo",
+                    "bar": [
+                        "date_of_birth": "2001-01-01T00:00:00Z"
+                    ]
+                ],
             ]
         )
 

--- a/Tests/MountebankSwiftTests/Models/Stub/Response/ResponseTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Response/ResponseTests.swift
@@ -36,10 +36,17 @@ final class ResponseTests: XCTestCase {
         )
     }
 
-    func testCodable() throws {
+    func testEncodable() throws {
         try assertEncode(
             Is.Examples.jsonEncodable.value,
             Is.Examples.jsonEncodable.json
+        )
+        // Not possible to decode json back into codable
+    }
+    func testEncodableCustomDateFormatAndKeyEncodingStrategy() throws {
+        try assertEncode(
+            Is.Examples.jsonEncodableCustomDateFormatAndKeyEncodingStrategy.value,
+            Is.Examples.jsonEncodableCustomDateFormatAndKeyEncodingStrategy.json
         )
         // Not possible to decode json back into codable
     }


### PR DESCRIPTION
When using an Encodable as a response, we use the [default date encoding strategy](https://developer.apple.com/documentation/foundation/jsonencoder/dateencodingstrategy) and [key encoding strategy](https://developer.apple.com/documentation/foundation/jsonencoder/keyencodingstrategy) to encode properties when we send the imposter to Mountebank. 

Therefore `let dateOfBirth: Date(timeIntervalSinceReferenceDate: 0)` becomes: `"dateOfBirth": 0`. But users might use different encoding strategies when encoding their own encodable in their network stack. This is not convenient because it effectively means those user can't use [our Encodable initialiser](https://github.com/MountebankSwift/MountebankSwift/blob/main/Sources/MountebankSwift/Models/Stub/Response/Is/Is%2Binitializers.swift#L51-L65) to create a `Is` response. See issue https://github.com/MountebankSwift/MountebankSwift/issues/23

This PR attempts to solve this by allowing to create a custom JSONEncoder, for example: 

```
let encoder = JSONEncoder()
encoder.dateEncodingStrategy = .iso8601
encoder.keyEncodingStrategy = .convertToSnakeCase
```

and to pass it along when creating a Encodable and JSON body. This should allow 
```
let dateOfBirth: Date(timeIntervalSinceReferenceDate: 0)
``` 
to become: 
```
"date_of_birth": "2001-01-01T00:00:00Z"
 ^^^^^^               ^^^^^
snake_case           .iso8601
```

