### PR TITLE
feat: add missing HTTPMethods;

### DIFF
--- a/Sources/MountebankSwift/Common/HTTPMethod.swift
+++ b/Sources/MountebankSwift/Common/HTTPMethod.swift
@@ -7,4 +7,8 @@ public enum HTTPMethod: String, Codable, Equatable {
     case post = "POST"
     case put = "PUT"
     case delete = "DELETE"
+    case connect = "CONNECT"
+    case options = "OPTIONS"
+    case trace = "TRACE"
+    case patch = "PATCH"
 }


### PR DESCRIPTION
Add the missing: `CONNECT`, `OPTIONS`, `TRACE` and `PATCH` methods. To cover all methods documented on https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods