### PR TITLE
Add Recreatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ DerivedData/
 mb.log
 mb*.log
 mb*.pid
+__Imposters__

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,24 @@
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "5b0c434778f2c1a4c9b5ebdb8682b28e84dd69bd",
+        "version" : "1.15.4"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -19,6 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.15.4"),
     ],
     targets: [
         .target(
@@ -27,7 +28,11 @@ let package = Package(
         ),
         .testTarget(
             name: "MountebankSwiftTests",
-            dependencies: ["MountebankSwift"],
+            dependencies: [
+                "MountebankSwift",
+                .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ],
             resources: [
                 .copy("ExampleData/Files"),
             ]

--- a/Sources/MountebankSwift/Common/FailableDecodable.swift
+++ b/Sources/MountebankSwift/Common/FailableDecodable.swift
@@ -5,10 +5,10 @@ struct FailableDecodable<Value: Decodable>: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         do {
-            self.value = try container.decode(Value.self)
+            value = try container.decode(Value.self)
         } catch {
             print("[Mountebank]: ❌ Unable to decode \(decoder.codingPath.map(\.stringValue)) as \(Value.self)")
-            self.value = nil
+            value = nil
         }
     }
 }

--- a/Sources/MountebankSwift/Common/HTTPMethod.swift
+++ b/Sources/MountebankSwift/Common/HTTPMethod.swift
@@ -12,3 +12,9 @@ public enum HTTPMethod: String, Codable, Equatable {
     case trace = "TRACE"
     case patch = "PATCH"
 }
+
+extension HTTPMethod: Recreatable {
+    var recreatable: String {
+        enumSwiftString()
+    }
+}

--- a/Sources/MountebankSwift/Common/JSON.swift
+++ b/Sources/MountebankSwift/Common/JSON.swift
@@ -81,9 +81,7 @@ public enum JSON: Codable, Hashable {
             )
         }
     }
-}
 
-extension JSON: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .string(let str):

--- a/Sources/MountebankSwift/Common/JSON.swift
+++ b/Sources/MountebankSwift/Common/JSON.swift
@@ -81,7 +81,9 @@ public enum JSON: Codable, Hashable {
             )
         }
     }
+}
 
+extension JSON: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .string(let str):
@@ -95,6 +97,21 @@ public enum JSON: Codable, Hashable {
         default:
             // swiftlint:disable:next force_try force_unwrapping
             return try! String(data: prettyPrintingJSONEncoder.encode(self), encoding: .utf8)!
+        }
+    }
+}
+
+extension JSON: Recreatable {
+    var recreatable: String {
+        switch self {
+        case .string(let value as Recreatable),
+             .number(let value as Recreatable),
+             .bool(let value as Recreatable),
+             .object(let value as Recreatable),
+             .array(let value as Recreatable):
+            return value.recreatable
+        case .null:
+            return enumSwiftString()
         }
     }
 }

--- a/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+extension Imposter {
+    public func writeStubsToDisk(
+        directoryName: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        let imposters = """
+        import Foundation
+        import MountebankSwift
+
+        let stubsFor\(name.map(sanitizeName)?.capitalized ?? ""): [Stub] = \(stubs.recreatable)
+        """
+
+        do {
+            let dirURL = URL(fileURLWithPath: "\(directoryName)", isDirectory: false)
+            let dirName = dirURL.deletingPathExtension().lastPathComponent
+            let directory = dirURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("Imposters")
+                .appendingPathComponent(dirName)
+
+            let fileName = [
+                sanitizePathComponent(testName),
+                name.map(sanitizePathComponent),
+                "swift",
+            ]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: ".")
+
+            let fileURL = directory.appendingPathComponent(fileName)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try imposters.write(to: fileURL, atomically: true, encoding: .utf8)
+        } catch {
+            print(error)
+        }
+    }
+
+    private func sanitizePathComponent(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "\\W+", with: "-", options: .regularExpression)
+            .replacingOccurrences(of: "^-|-$", with: "", options: .regularExpression)
+    }
+
+    private func sanitizeName(_ string: String) -> String {
+        string.replacingOccurrences(of: "\\W+", with: "", options: .regularExpression)
+    }
+}

--- a/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
@@ -13,28 +13,29 @@ extension Imposter {
         let stubsFor\(name.map(sanitizeName)?.capitalized ?? ""): [Stub] = \(stubs.recreatable)
         """
 
-        do {
-            let dirURL = URL(fileURLWithPath: "\(directoryName)", isDirectory: false)
-            let dirName = dirURL.deletingPathExtension().lastPathComponent
-            let directory = dirURL
-                .deletingLastPathComponent()
-                .appendingPathComponent("Imposters")
-                .appendingPathComponent(dirName)
+        let dirURL = URL(fileURLWithPath: "\(directoryName)", isDirectory: false)
+        let dirName = dirURL.deletingPathExtension().lastPathComponent
+        let directory = dirURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("Imposters")
+            .appendingPathComponent(dirName)
 
-            let fileName = [
-                sanitizePathComponent(testName),
-                name.map(sanitizePathComponent),
-                "swift",
-            ]
+        let fileName = [
+            sanitizePathComponent(testName),
+            name.map(sanitizePathComponent),
+            "swift",
+        ]
             .compactMap { $0 }
             .filter { !$0.isEmpty }
             .joined(separator: ".")
 
-            let fileURL = directory.appendingPathComponent(fileName)
+        let fileURL = directory.appendingPathComponent(fileName)
+
+        do {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             try imposters.write(to: fileURL, atomically: true, encoding: .utf8)
         } catch {
-            print(error)
+            print("[Mountebank]: ❌ Failed to write stubs to \(fileURL): \(error)")
         }
     }
 

--- a/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
@@ -5,7 +5,7 @@ extension Imposter {
         directoryName: StaticString = #file,
         testName: String = #function,
         line: UInt = #line
-    ) {
+    ) throws {
         let imposters = """
         import Foundation
         import MountebankSwift
@@ -31,12 +31,8 @@ extension Imposter {
 
         let fileURL = directory.appendingPathComponent(fileName)
 
-        do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            try imposters.write(to: fileURL, atomically: true, encoding: .utf8)
-        } catch {
-            print("[Mountebank]: ❌ Failed to write stubs to \(fileURL): \(error)")
-        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try imposters.write(to: fileURL, atomically: true, encoding: .utf8)
     }
 
     private func sanitizePathComponent(_ string: String) -> String {

--- a/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
@@ -3,36 +3,50 @@ import Foundation
 extension Imposter {
     public func writeStubsToDisk(
         directoryName: StaticString = #file,
-        testName: String = #function,
-        line: UInt = #line
+        methodName: String = #function
     ) throws {
         let imposters = """
         import Foundation
         import MountebankSwift
 
+        // swiftlint:disable line_length force_unwrapping
         let stubsFor\(name.map(sanitizeName)?.capitalized ?? ""): [Stub] = \(stubs.recreatable)
+        // swiftlint:enable line_length force_unwrapping
+
         """
 
         let dirURL = URL(fileURLWithPath: "\(directoryName)", isDirectory: false)
         let dirName = dirURL.deletingPathExtension().lastPathComponent
         let directory = dirURL
             .deletingLastPathComponent()
-            .appendingPathComponent("Imposters")
+            .appendingPathComponent("__Imposters__")
             .appendingPathComponent(dirName)
 
+        try writeToDisk(
+            content: imposters,
+            directory: directory,
+            methodName: methodName
+        )
+    }
+
+    private func writeToDisk(
+        content: String,
+        directory: URL,
+        methodName: String
+    ) throws {
         let fileName = [
-            sanitizePathComponent(testName),
+            sanitizePathComponent(methodName),
             name.map(sanitizePathComponent),
             "swift",
         ]
-            .compactMap { $0 }
-            .filter { !$0.isEmpty }
-            .joined(separator: ".")
+        .compactMap { $0 }
+        .filter { !$0.isEmpty }
+        .joined(separator: ".")
 
         let fileURL = directory.appendingPathComponent(fileName)
 
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try imposters.write(to: fileURL, atomically: true, encoding: .utf8)
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
     }
 
     private func sanitizePathComponent(_ string: String) -> String {
@@ -42,6 +56,6 @@ extension Imposter {
     }
 
     private func sanitizeName(_ string: String) -> String {
-        string.replacingOccurrences(of: "\\W+", with: "", options: .regularExpression)
+        string.replacingOccurrences(of: "\\W+", with: "_", options: .regularExpression)
     }
 }

--- a/Sources/MountebankSwift/Models/Imposter/Imposters.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposters.swift
@@ -5,3 +5,9 @@ import Foundation
 struct Imposters: Codable, Equatable {
     public let imposters: [Imposter]
 }
+
+extension Imposters: Recreatable {
+    var recreatable: String {
+        structSwiftString([("imposters", imposters)])
+    }
+}

--- a/Sources/MountebankSwift/Models/Recreatable.swift
+++ b/Sources/MountebankSwift/Models/Recreatable.swift
@@ -136,7 +136,7 @@ extension Bool: Recreatable {
 
 extension Data: Recreatable {
     var recreatable: String {
-        "Data(base64Encoded: \(base64EncodedString().debugDescription))!"
+        "Data(base64Encoded: \(base64EncodedString().recreatable))!"
     }
 }
 

--- a/Sources/MountebankSwift/Models/Recreatable.swift
+++ b/Sources/MountebankSwift/Models/Recreatable.swift
@@ -10,9 +10,9 @@ protocol Recreatable {
 
 // MARK: - Public Helpers
 
-private let DELIMITER = ",\n"
-private let WHITESPACE = "    "
-private var INDENT = 0
+private let delimiter = ",\n"
+private let whitespace = "    "
+private var indent = 0
 
 extension Recreatable {
     /// Helper to create a recreatable string for a struct
@@ -37,10 +37,10 @@ extension Recreatable {
             return ".\(enumCaseWithoutAssociatedValues)"
         }
 
-        let increaseIndent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
-        INDENT += increaseIndent
+        let increaseindent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
+        indent += increaseindent
         defer {
-            INDENT -= increaseIndent
+            indent -= increaseindent
         }
 
         let propertyList = properties
@@ -51,14 +51,12 @@ extension Recreatable {
         case 0:
             return ".\(enumCaseWithoutAssociatedValues)()"
         case 1:
-            return ".\(enumCaseWithoutAssociatedValues)(\(propertyList.joined(separator: DELIMITER)))"
+            return ".\(enumCaseWithoutAssociatedValues)(\(propertyList.joined(separator: delimiter)))"
         default:
-            let indent = String(repeating: WHITESPACE, count: INDENT)
-            let string = propertyList.map { indent + $0 }.joined(separator: DELIMITER)
             return """
             .\(enumCaseWithoutAssociatedValues)(
-            \(string)
-            \(String(repeating: WHITESPACE, count: INDENT - 1)))
+            \(indentedList(propertyList))
+            \(String(repeating: whitespace, count: indent - 1)))
             """
         }
     }
@@ -68,10 +66,10 @@ extension Recreatable {
 
 extension Recreatable {
     private func structOrClassSwiftString(properties: [(String?, Recreatable?)]) -> String {
-        let increaseIndent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
-        INDENT += increaseIndent
+        let increaseindent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
+        indent += increaseindent
         defer {
-            INDENT -= increaseIndent
+            indent -= increaseindent
         }
 
         let propertyList = properties
@@ -82,14 +80,12 @@ extension Recreatable {
         case 0:
             return "\(Self.self)()"
         case 1:
-            return "\(Self.self)(\(propertyList.joined(separator: DELIMITER)))"
+            return "\(Self.self)(\(propertyList.joined(separator: delimiter)))"
         default:
-            let indent = String(repeating: WHITESPACE, count: INDENT)
-            let string = propertyList.map { indent + $0 }.joined(separator: DELIMITER)
             return """
             \(Self.self)(
-            \(string)
-            \(String(repeating: WHITESPACE, count: INDENT - 1)))
+            \(indentedList(propertyList))
+            \(String(repeating: whitespace, count: indent - 1)))
             """
         }
     }
@@ -150,10 +146,10 @@ extension Dictionary: Recreatable {
             return "[:]"
         }
 
-        let increaseIndent = filter({ $0.value is Recreatable }).count > 1 ? 1 : 0
-        INDENT += increaseIndent
+        let increaseindent = filter({ $0.value is Recreatable }).count > 1 ? 1 : 0
+        indent += increaseindent
         defer {
-            INDENT -= increaseIndent
+            indent -= increaseindent
         }
 
         let keyValuePairs = map { key, value in
@@ -171,14 +167,12 @@ extension Dictionary: Recreatable {
         case 0:
             return "[:]"
         case 1:
-            return "[\(keyValuePairs.joined(separator: DELIMITER))]"
+            return "[\(keyValuePairs.joined(separator: delimiter))]"
         default:
-            let indent = String(repeating: WHITESPACE, count: INDENT)
-            let string = keyValuePairs.map { indent + $0 }.joined(separator: DELIMITER)
             return """
             [
-            \(string)
-            \(String(repeating: WHITESPACE, count: INDENT - 1))]
+            \(indentedList(keyValuePairs))
+            \(String(repeating: whitespace, count: indent - 1))]
             """
         }
     }
@@ -190,10 +184,10 @@ extension Array: Recreatable {
             return "[]"
         }
 
-        let increaseIndent = filter({ $0 is Recreatable }).count > 1 ? 1 : 0
-        INDENT += increaseIndent
+        let increaseindent = filter({ $0 is Recreatable }).count > 1 ? 1 : 0
+        indent += increaseindent
         defer {
-            INDENT -= increaseIndent
+            indent -= increaseindent
         }
 
         let elements = compactMap { element in
@@ -208,15 +202,19 @@ extension Array: Recreatable {
         case 0:
             return "[]"
         case 1:
-            return "[\(elements.joined(separator: DELIMITER))]"
+            return "[\(elements.joined(separator: delimiter))]"
         default:
-            let indent = String(repeating: WHITESPACE, count: INDENT)
-            let string = elements.map { indent + $0 }.joined(separator: DELIMITER)
             return """
             [
-            \(string)
-            \(String(repeating: WHITESPACE, count: INDENT - 1))]
+            \(indentedList(elements))
+            \(String(repeating: whitespace, count: indent - 1))]
             """
         }
     }
+}
+
+private func indentedList(_ list: [String]) -> String {
+    list
+        .map { String(repeating: whitespace, count: indent) + $0 }
+        .joined(separator: delimiter)
 }

--- a/Sources/MountebankSwift/Models/Recreatable.swift
+++ b/Sources/MountebankSwift/Models/Recreatable.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+// MARK: - Protocol
+
+/// Protocol for re-creating swift code from an instance.
+/// Use the helper methods below. See extensions on models for examples
+protocol Recreatable {
+    var recreatable: String { get }
+}
+
+// MARK: - Public Helpers
+
+private let DELIMITER = ",\n"
+private let WHITESPACE = "    "
+private var INDENT = 0
+
+extension Recreatable {
+    /// Helper to create a recreatable string for a struct
+    func structSwiftString(_ properties: [(key: String?, label: Recreatable?)]) -> String {
+        structOrClassSwiftString(properties: properties)
+    }
+
+    /// Helper to create a recreatable string for a class
+    func classSwiftString(_ properties: [(String?, Recreatable?)]) -> String {
+        structOrClassSwiftString(properties: properties)
+    }
+
+    /// Helper to create a recreatable string for an enum without labeled associated values
+    func enumSwiftString(_ properties: [Recreatable?] = []) -> String {
+        enumSwiftString(properties.map { (nil, $0) })
+    }
+
+    /// Helper to create a recreatable string for an enum with labeled associated values
+    func enumSwiftString(_ properties: [(String?, Recreatable?)]) -> String {
+        let enumCaseWithoutAssociatedValues = "\(self)".split(separator: "(").first.map(String.init) ?? "\(self)"
+        if properties.isEmpty {
+            return ".\(enumCaseWithoutAssociatedValues)"
+        }
+
+        let increaseIndent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
+        INDENT += increaseIndent
+        defer {
+            INDENT -= increaseIndent
+        }
+
+        let propertyList = properties
+            .map { Self.propertySwiftString($0, $1) }
+            .filter { !$0.isEmpty }
+
+        switch propertyList.count {
+        case 0:
+            return ".\(enumCaseWithoutAssociatedValues)()"
+        case 1:
+            return ".\(enumCaseWithoutAssociatedValues)(\(propertyList.joined(separator: DELIMITER)))"
+        default:
+            let indent = String(repeating: WHITESPACE, count: INDENT)
+            let string = propertyList.map { indent + $0 }.joined(separator: DELIMITER)
+            return """
+            .\(enumCaseWithoutAssociatedValues)(
+            \(string)
+            \(String(repeating: WHITESPACE, count: INDENT - 1)))
+            """
+        }
+    }
+}
+
+// MARK: - Private Helpers
+
+extension Recreatable {
+    private func structOrClassSwiftString(properties: [(String?, Recreatable?)]) -> String {
+        let increaseIndent = properties.filter { $0.1?.recreatable.isEmpty == false }.count > 1 ? 1 : 0
+        INDENT += increaseIndent
+        defer {
+            INDENT -= increaseIndent
+        }
+
+        let propertyList = properties
+            .map { Self.propertySwiftString($0, $1) }
+            .filter { !$0.isEmpty }
+
+        switch propertyList.count {
+        case 0:
+            return "\(Self.self)()"
+        case 1:
+            return "\(Self.self)(\(propertyList.joined(separator: DELIMITER)))"
+        default:
+            let indent = String(repeating: WHITESPACE, count: INDENT)
+            let string = propertyList.map { indent + $0 }.joined(separator: DELIMITER)
+            return """
+            \(Self.self)(
+            \(string)
+            \(String(repeating: WHITESPACE, count: INDENT - 1)))
+            """
+        }
+    }
+
+    private static func propertySwiftString(_ label: String?, _ value: Recreatable?) -> String {
+        guard let value else {
+            return ""
+        }
+
+        let recreatable = value.recreatable
+        guard !recreatable.isEmpty else {
+            return ""
+        }
+
+        if let label {
+            return "\(label): \(recreatable)"
+        } else {
+            return "\(recreatable)"
+        }
+    }
+}
+
+// MARK: - Extensions on Swift Types
+
+extension String: Recreatable {
+    var recreatable: String {
+        debugDescription
+    }
+}
+
+extension Int: Recreatable {
+    var recreatable: String {
+        description
+    }
+}
+
+extension Double: Recreatable {
+    var recreatable: String {
+        debugDescription
+    }
+}
+
+extension Bool: Recreatable {
+    var recreatable: String {
+        description
+    }
+}
+
+extension Data: Recreatable {
+    var recreatable: String {
+        "Data(base64Encoded: \(base64EncodedString().debugDescription))!"
+    }
+}
+
+extension Dictionary: Recreatable {
+    var recreatable: String {
+        if isEmpty {
+            return "[:]"
+        }
+
+        let increaseIndent = filter({ $0.value is Recreatable }).count > 1 ? 1 : 0
+        INDENT += increaseIndent
+        defer {
+            INDENT -= increaseIndent
+        }
+
+        let keyValuePairs = map { key, value in
+            guard let recreatableKey = key as? Recreatable else {
+                return "[Mountebank.Recreatable]: ❌ \(type(of: key)) does not conform to Recreatable"
+            }
+            guard let recreatableValue = value as? Recreatable else {
+                return "[Mountebank.Recreatable]: ❌ \(type(of: value)) does not conform to Recreatable"
+            }
+
+            return "\(recreatableKey.recreatable): \(recreatableValue.recreatable)"
+        }.sorted()
+
+        switch keyValuePairs.count {
+        case 0:
+            return "[:]"
+        case 1:
+            return "[\(keyValuePairs.joined(separator: DELIMITER))]"
+        default:
+            let indent = String(repeating: WHITESPACE, count: INDENT)
+            let string = keyValuePairs.map { indent + $0 }.joined(separator: DELIMITER)
+            return """
+            [
+            \(string)
+            \(String(repeating: WHITESPACE, count: INDENT - 1))]
+            """
+        }
+    }
+}
+
+extension Array: Recreatable {
+    var recreatable: String {
+        if isEmpty {
+            return "[]"
+        }
+
+        let increaseIndent = filter({ $0 is Recreatable }).count > 1 ? 1 : 0
+        INDENT += increaseIndent
+        defer {
+            INDENT -= increaseIndent
+        }
+
+        let elements = compactMap { element in
+            guard let recreatable = element as? Recreatable else {
+                return "[Mountebank.Recreatable]: ❌ \(type(of: element)) does not conform to Recreatable"
+            }
+
+            return recreatable.recreatable
+        }
+
+        switch elements.count {
+        case 0:
+            return "[]"
+        case 1:
+            return "[\(elements.joined(separator: DELIMITER))]"
+        default:
+            let indent = String(repeating: WHITESPACE, count: INDENT)
+            let string = elements.map { indent + $0 }.joined(separator: DELIMITER)
+            return """
+            [
+            \(string)
+            \(String(repeating: WHITESPACE, count: INDENT - 1))]
+            """
+        }
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
@@ -15,6 +15,6 @@ public struct JSONPath: Codable, Equatable {
 
 extension JSONPath: Recreatable {
     var recreatable: String {
-        "JSONPath(selector: \(selector.debugDescription))"
+        "JSONPath(selector: \(selector.recreatable))"
     }
 }

--- a/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
@@ -12,3 +12,9 @@ public struct JSONPath: Codable, Equatable {
         self.selector = selector
     }
 }
+
+extension JSONPath: Recreatable {
+    var recreatable: String {
+        "JSONPath(selector: \(selector.debugDescription))"
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Predicate/Predicate.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/Predicate.swift
@@ -81,3 +81,25 @@ extension Predicate {
         )
     }
 }
+
+extension Predicate: Recreatable {
+    var recreatable: String {
+        switch self {
+        case .equals(let request, let predicateParameters),
+             .deepEquals(let request, let predicateParameters),
+             .contains(let request, let predicateParameters),
+             .startsWith(let request, let predicateParameters),
+             .endsWith(let request, let predicateParameters),
+             .matches(let request, let predicateParameters),
+             .exists(let request, let predicateParameters):
+            return enumSwiftString([request, predicateParameters])
+        case .not(let predicate, let predicateParameters):
+            return enumSwiftString([predicate, predicateParameters])
+        case .or(let array, let predicateParameters),
+             .and(let array, let predicateParameters):
+            return enumSwiftString([array, predicateParameters])
+        case .inject(let string):
+            return enumSwiftString([string])
+        }
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Predicate/PredicateParameters.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/PredicateParameters.swift
@@ -35,3 +35,14 @@ public struct PredicateParameters: Equatable {
         }
     }
 }
+
+extension PredicateParameters: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("caseSensitive", caseSensitive),
+            ("except", except),
+            ("xPath", xPath),
+            ("jsonPath", jsonPath),
+        ])
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Predicate/Request.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/Request.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The predicate will use all the optional fields in this request to try to match an incoming request made by the
 /// application under test
-public struct Request: Equatable, Codable, CustomDebugStringConvertible {
+public struct Request: Equatable, Codable {
     public let method: HTTPMethod?
     public let path: String?
     public let query: [String: JSON]?
@@ -27,5 +27,17 @@ public struct Request: Equatable, Codable, CustomDebugStringConvertible {
         [method.map(\.rawValue), path]
             .compactMap { $0 }
             .joined(separator: " ")
+    }
+}
+
+extension Request: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("method", method),
+            ("path", path),
+            ("query", query),
+            ("headers", headers),
+            ("data", data),
+        ])
     }
 }

--- a/Sources/MountebankSwift/Models/Stub/Predicate/XPath.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/XPath.swift
@@ -21,3 +21,12 @@ public struct XPath: Codable, Equatable {
         self.namespace = namespace
     }
 }
+
+extension XPath: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("selector", selector),
+            ("namespace", namespace),
+        ])
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.BehaviorCopyMethod.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.BehaviorCopyMethod.swift
@@ -42,3 +42,31 @@ extension Behavior {
         case jsonpath(selector: String)
     }
 }
+
+extension Behavior.BehaviorCopyMethod: Recreatable {
+    var recreatable: String {
+        var properties: [(String, Recreatable?)] = []
+        switch self {
+        case .regex(let selector, let options):
+            properties.append(("selector", selector))
+            properties.append(("options", options))
+        case .xpath(let selector, let namespace):
+            properties.append(("selector", selector))
+            properties.append(("namespace", namespace))
+        case .jsonpath(let selector):
+            properties.append(("selector", selector))
+        }
+
+        return enumSwiftString(properties)
+    }
+}
+
+extension Behavior.BehaviorCopyMethod.Options: Recreatable {
+    var recreatable: String {
+        let values = [
+            contains(Self.ignoreCase) ? ".ignoreCase" : nil,
+            contains(Self.multiline) ? ".multiline" : nil,
+        ].compactMap { $0 }.joined(separator: ", ")
+        return "Options([\(values)])"
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.swift
@@ -41,3 +41,24 @@ public enum Behavior: Equatable {
     /// The `--allowInjection` command line flag must be set to support this behavior.
     case shellTransform(String)
 }
+
+extension Behavior: Recreatable {
+    var recreatable: String {
+        switch self {
+        case .wait(let miliseconds):
+            return enumSwiftString([("miliseconds", miliseconds)])
+        case .copy(let from, let into, let using):
+            return enumSwiftString([
+                ("from", from),
+                ("into", into),
+                ("using", using),
+            ])
+        case .lookup(let json):
+            return enumSwiftString([json])
+        case .waitJavascript(let string),
+             .decorate(let string),
+             .shellTransform(let string):
+            return enumSwiftString([string])
+        }
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Fault.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Fault.swift
@@ -6,9 +6,16 @@ import Foundation
 /// respond as expected due to network failures. Mountebank already has the ability to specify delays
 /// via `wait` but we may also want to test when the connection is abruptly reset or garbage data is
 /// returned, similar to some of Wiremock's fault simulation functionality
-public enum Fault: String, StubResponse, Codable, Equatable { // TODO convert to struct? To add parameters
+public enum Fault: String, StubResponse, Codable, Equatable {
+    // TODO convert to struct? To add parameters
     /// Close the connection.
     case connectionResetByPeer = "CONNECTION_RESET_BY_PEER"
     /// Send garbage then close the connection.
     case randomDataThenClose = "RANDOM_DATA_THEN_CLOSE"
+}
+
+extension Fault: Recreatable {
+    var recreatable: String {
+        "Fault.\(self)"
+    }
 }

--- a/Sources/MountebankSwift/Models/Stub/Response/Inject.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Inject.swift
@@ -21,6 +21,6 @@ public struct Inject: StubResponse, Codable, Equatable {
 
 extension Inject: Recreatable {
     var recreatable: String {
-        "Inject(\(injection.debugDescription))"
+        "Inject(\(injection.recreatable))"
     }
 }

--- a/Sources/MountebankSwift/Models/Stub/Response/Inject.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Inject.swift
@@ -18,3 +18,9 @@ public struct Inject: StubResponse, Codable, Equatable {
         try injection.encode(to: encoder)
     }
 }
+
+extension Inject: Recreatable {
+    var recreatable: String {
+        "Inject(\(injection.debugDescription))"
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
@@ -48,7 +48,7 @@ extension Body: Recreatable {
                 let json = try jsonDecoder.decode(JSON.self, from: data)
                 return Body.json("").enumSwiftString([json])
             } catch {
-                return ">>>> FAILED TO ENCODE ENCODABLE <<<<"
+                return "[Mountebank]: ❌ Failed to encode object: \(error)"
             }
         case .data(let data):
             return enumSwiftString([data])

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
@@ -34,3 +34,24 @@ public enum Body: Equatable {
         }
     }
 }
+
+extension Body: Recreatable {
+    var recreatable: String {
+        switch self {
+        case .text(let string):
+            return enumSwiftString([string])
+        case .json(let json):
+            return enumSwiftString([json])
+        case .jsonEncodable(let encodable, let encoder):
+            do {
+                let data = try (encoder ?? jsonEncoder).encode(encodable)
+                let json = try jsonDecoder.decode(JSON.self, from: data)
+                return Body.json("").enumSwiftString([json])
+            } catch {
+                return ">>>> FAILED TO ENCODE ENCODABLE <<<<"
+            }
+        case .data(let data):
+            return enumSwiftString([data])
+        }
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is.swift
@@ -53,3 +53,14 @@ public struct Is: StubResponse, Equatable {
             )
     }
 }
+
+extension Is: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("statusCode", statusCode),
+            ("headers", headers),
+            ("body", body),
+            ("parameters", parameters),
+        ])
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Proxy/PredicateGenerator.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Proxy/PredicateGenerator.swift
@@ -39,3 +39,36 @@ public enum PredicateGenerator: Equatable {
     /// Defines a JavaScript function that allows programmatic creation of the predicates.
     case inject(String)
 }
+
+extension PredicateGenerator: Recreatable {
+    var recreatable: String {
+        switch self {
+        case .inject(let inject):
+            return enumSwiftString([inject])
+        case .matches(
+            let fields,
+            let predicateOperator,
+            let caseSensitive,
+            let except,
+            let xPath,
+            let jsonPath,
+            let ignore
+        ):
+            return enumSwiftString([
+                ("fields", fields),
+                ("predicateOperator", predicateOperator),
+                ("caseSensitive", caseSensitive),
+                ("except", except),
+                ("xPath", xPath),
+                ("jsonPath", jsonPath),
+                ("ignore", ignore),
+            ])
+        }
+    }
+}
+
+extension PredicateOperator: Recreatable {
+    var recreatable: String {
+        enumSwiftString()
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/Proxy/Proxy.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Proxy/Proxy.swift
@@ -110,3 +110,21 @@ public struct Proxy: StubResponse, Codable, Equatable {
         self.addDecorateBehavior = addDecorateBehavior
     }
 }
+
+extension Proxy: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("to", to),
+            ("mode", mode),
+            ("predicateGenerators", predicateGenerators),
+            ("addWaitBehavior", addWaitBehavior),
+            ("addDecorateBehavior", addDecorateBehavior),
+        ])
+    }
+}
+
+extension Proxy.Mode: Recreatable {
+    var recreatable: String {
+        enumSwiftString()
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Response/ResponseParameters.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/ResponseParameters.swift
@@ -20,3 +20,12 @@ public struct ResponseParameters: Equatable {
         }
     }
 }
+
+extension ResponseParameters: Recreatable {
+    var recreatable: String {
+        structSwiftString([
+            ("repeatCount", repeatCount),
+            ("behaviors", behaviors),
+        ])
+    }
+}

--- a/Sources/MountebankSwift/Models/Stub/Stub.swift
+++ b/Sources/MountebankSwift/Models/Stub/Stub.swift
@@ -58,3 +58,37 @@ public struct Stub: Equatable {
         self.init(responses: [response], predicates: [])
     }
 }
+
+extension Stub: Recreatable {
+    var recreatable: String {
+        structSwiftString([responseProperty, predicateProperty])
+    }
+
+    private var responseProperty: (String, Recreatable) {
+        if responses.count == 1 {
+            // swiftlint:disable:next force_unwrapping
+            switch responses.first!.codable {
+            case .is(let response):
+                return ("response", response)
+            case .proxy(let response):
+                return ("response", response)
+            case .inject(let response):
+                return ("response", response)
+            case .fault(let response):
+                return ("response", response)
+            }
+        } else {
+            return ("responses", responses)
+        }
+    }
+
+    private var predicateProperty: (String, Recreatable) {
+        guard !predicates.isEmpty else {
+            return ("predicates", [Predicate]())
+        }
+
+        return predicates.count == 1
+            ? ("predicate", predicates[0])
+            : ("predicates", predicates)
+    }
+}

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Proxy+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Proxy+Examples.swift
@@ -3,6 +3,12 @@ import MountebankSwift
 
 extension Proxy {
     enum Examples {
+        static let all: [Example] = [
+            simple,
+            advanced,
+            predicateGenerators,
+        ]
+
         static let simple = Example(
             value: Proxy(
                 to: "https://www.somesite.com:3000",

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Stub+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Stub+Examples.swift
@@ -6,6 +6,9 @@ extension Stub {
         static let all: [Example] = [
             text,
             json,
+            simpleProxy,
+            advancedProxy,
+            predicateGeneratorsProxy,
             noPredicates,
             http404,
             textWhenRefresh404,
@@ -64,6 +67,33 @@ extension Stub {
                 "predicates": [
                     ["equals" : ["path": "/404-to-200"]],
                 ],
+            ]
+        )
+
+        static let simpleProxy = Example(
+            value: Stub(
+                response: Proxy.Examples.simple.value
+            ),
+            json: [
+                "responses": [["proxy": Proxy.Examples.simple.json]],
+            ]
+        )
+
+        static let advancedProxy = Example(
+            value: Stub(
+                response: Proxy.Examples.advanced.value
+            ),
+            json: [
+                "responses": [["proxy": Proxy.Examples.advanced.json]],
+            ]
+        )
+
+        static let predicateGeneratorsProxy = Example(
+            value: Stub(
+                response: Proxy.Examples.predicateGenerators.value
+            ),
+            json: [
+                "responses": [["proxy": Proxy.Examples.predicateGenerators.json]],
             ]
         )
 

--- a/Tests/MountebankSwiftTests/Models/ImposterTests.swift
+++ b/Tests/MountebankSwiftTests/Models/ImposterTests.swift
@@ -85,9 +85,9 @@ final class ImposterTests: XCTestCase {
                         "headers": [
                             "X-My-Invalid-header-type-should-be-string" : 42,
                             "X-Invalid-headers.." : "should be ignored",
-                        ]
-                    ]
-                ]
+                        ],
+                    ],
+                ],
             ],
             Imposter(
                 port: 123,
@@ -102,7 +102,7 @@ final class ImposterTests: XCTestCase {
                         requestFrom: "127.0.0.1",
                         ip: "127.0.0.1",
                         timestamp: Date(timeIntervalSince1970: 1702066146.263)
-                    )
+                    ),
                 ]
             )
         )

--- a/Tests/MountebankSwiftTests/Models/ImposterTests.swift
+++ b/Tests/MountebankSwiftTests/Models/ImposterTests.swift
@@ -107,4 +107,8 @@ final class ImposterTests: XCTestCase {
             )
         )
     }
+
+    func testWriteToDisk() throws {
+        try Imposter.Examples.includingAllStubs.value.writeStubsToDisk()
+    }
 }

--- a/Tests/MountebankSwiftTests/Models/RecreatableTests.swift
+++ b/Tests/MountebankSwiftTests/Models/RecreatableTests.swift
@@ -1,0 +1,315 @@
+import InlineSnapshotTesting
+import XCTest
+@testable import MountebankSwift
+
+final class RecreatableTests: XCTestCase {
+    struct MyStruct: Recreatable {
+        let foo: String?
+        let bar: [Int]
+        let enumValue: MyEnum
+        let json: JSON?
+
+        var recreatable: String {
+            structSwiftString([
+                ("foo", foo),
+                ("bar", bar),
+                ("enumValue", enumValue),
+                ("json", json),
+            ])
+        }
+    }
+
+    indirect enum MyEnum: Recreatable {
+        case simple
+        case associatedValue(String)
+        case namedAssociatedValues(foo: String, bar: String)
+        case structValue(structValue: MyStruct)
+
+        var recreatable: String {
+            switch self {
+            case .simple:
+                return enumSwiftString()
+            case .associatedValue(let string):
+                return enumSwiftString([string])
+            case .namedAssociatedValues(let foo, let bar):
+                return enumSwiftString([("foo", foo), ("bar", bar)])
+            case .structValue(let structValue):
+                return enumSwiftString([("structValue", structValue)])
+            }
+        }
+    }
+
+    func testString() {
+        assertInlineSnapshot(of: "some string value".recreatable, as: .lines) {
+            """
+            "some string value"
+            """
+        }
+    }
+
+    func testInt() {
+        assertInlineSnapshot(of: 42.recreatable, as: .lines) {
+            """
+            42
+            """
+        }
+    }
+
+    func testDouble() {
+        assertInlineSnapshot(of: 42.0.recreatable, as: .lines) {
+            """
+            42.0
+            """
+        }
+    }
+
+    func testBool() {
+        assertInlineSnapshot(of: true.recreatable, as: .lines) {
+            """
+            true
+            """
+        }
+    }
+
+    func testData() {
+        let stringValue = "some-string"
+        // swiftlint:disable:next force_unwrapping
+        let data: Data = stringValue.data(using: .utf8)!
+        assertInlineSnapshot(of: data.recreatable, as: .lines) {
+            """
+            Data(base64Encoded: "c29tZS1zdHJpbmc=")!
+            """
+        }
+        XCTAssertEqual(
+            // swiftlint:disable:next force_unwrapping
+            String(bytes: Data(base64Encoded: "c29tZS1zdHJpbmc=")!, encoding: .utf8),
+            stringValue
+        )
+    }
+
+    func testEnum() {
+        assertInlineSnapshot(of: MyEnum.simple.recreatable, as: .lines) {
+            """
+            .simple
+            """
+        }
+        assertInlineSnapshot(of: MyEnum.associatedValue("foo-bar").recreatable, as: .lines) {
+            """
+            .associatedValue("foo-bar")
+            """
+        }
+        assertInlineSnapshot(of: MyEnum.namedAssociatedValues(foo: "foo", bar: "bar").recreatable, as: .lines) {
+            """
+            .namedAssociatedValues(
+                foo: "foo",
+                bar: "bar"
+            )
+            """
+        }
+    }
+
+    func testStruct() {
+        assertInlineSnapshot(
+            of: MyStruct(
+                foo: "foo",
+                bar: [42, 4, 2],
+                enumValue: .namedAssociatedValues(foo: "aa", bar: "bb"),
+                json: nil
+            ).recreatable,
+            as: .lines
+        ) {
+            """
+            MyStruct(
+                foo: "foo",
+                bar: [
+                    42,
+                    4,
+                    2
+                ],
+                enumValue: .namedAssociatedValues(
+                    foo: "aa",
+                    bar: "bb"
+                )
+            )
+            """
+        }
+    }
+
+    func testNesting() {
+        assertInlineSnapshot(
+            of: MyStruct(
+                foo: "foo",
+                bar: [42, 4, 2],
+                enumValue: .structValue(
+                    structValue: MyStruct(
+                        foo: "foo",
+                        bar: [333333],
+                        enumValue: .associatedValue("why would you want this?"),
+                        json: nil
+                    )
+                ),
+                json: nil
+            ).recreatable,
+            as: .lines
+        ) {
+            """
+            MyStruct(
+                foo: "foo",
+                bar: [
+                    42,
+                    4,
+                    2
+                ],
+                enumValue: .structValue(structValue: MyStruct(
+                    foo: "foo",
+                    bar: [333333],
+                    enumValue: .associatedValue("why would you want this?")
+                ))
+            )
+            """
+        }
+    }
+
+    func testDictionary() {
+        let stringDict: [String: Any] = [
+            "string": "value",
+            "int": 42,
+            "double": 42.0,
+            "bool": true,
+            "array": [
+                "foo",
+                "bar",
+                "baz",
+            ],
+            "dictionary": [
+                "string": "value",
+                "int": 42,
+                "double": 42.0,
+                "bool": true,
+                "dictionary": [
+                    "string": "value",
+                    "int": 42,
+                    "double": 42.0,
+                    "bool": true,
+                ],
+            ],
+        ]
+
+        assertInlineSnapshot(of: stringDict.recreatable, as: .lines) {
+            """
+            [
+                "array": [
+                    "foo",
+                    "bar",
+                    "baz"
+                ],
+                "bool": true,
+                "dictionary": [
+                    "bool": true,
+                    "dictionary": [
+                        "bool": true,
+                        "double": 42.0,
+                        "int": 42,
+                        "string": "value"
+                    ],
+                    "double": 42.0,
+                    "int": 42,
+                    "string": "value"
+                ],
+                "double": 42.0,
+                "int": 42,
+                "string": "value"
+            ]
+            """
+        }
+    }
+
+    func testArray() {
+        assertInlineSnapshot(of: ["foo", "bar", "baz"].recreatable, as: .lines) {
+            """
+            [
+                "foo",
+                "bar",
+                "baz"
+            ]
+            """
+        }
+    }
+
+    func testEmptyString() {
+        assertInlineSnapshot(of: ["", "second", "first"].recreatable, as: .lines) {
+            """
+            [
+                "",
+                "second",
+                "first"
+            ]
+            """
+        }
+    }
+
+    func testRequestWithEmptyQueryDictionary() {
+        assertInlineSnapshot(of: Request(query: [:]).recreatable, as: .lines) {
+            """
+            Request(query: [:])
+            """
+        }
+    }
+
+    func testEmptyStringInStruct() {
+        assertInlineSnapshot(of: MyStruct(foo: nil, bar: [], enumValue: .simple, json: nil).recreatable, as: .lines) {
+            """
+            MyStruct(
+                bar: [],
+                enumValue: .simple
+            )
+            """
+        }
+    }
+
+    func testJSON() {
+        let json: JSON = [
+            "string": "value",
+            "int": 42,
+            "dictionary": [
+                "double": 42.0,
+                "bool": true,
+                "array": [
+                    "foo",
+                    "bar",
+                ],
+                "nested": [
+                    "query": true,
+                ],
+                "null": .null,
+            ],
+        ]
+
+        assertInlineSnapshot(
+            of: MyStruct(foo: nil, bar: [], enumValue: .simple, json: json).recreatable,
+            as: .lines
+        ) {
+            """
+            MyStruct(
+                bar: [],
+                enumValue: .simple,
+                json: [
+                    "dictionary": [
+                        "array": [
+                            "foo",
+                            "bar"
+                        ],
+                        "bool": true,
+                        "double": 42.0,
+                        "nested": ["query": true],
+                        "null": .null
+                    ],
+                    "int": 42.0,
+                    "string": "value"
+                ]
+            )
+            """
+        }
+
+    }
+}

--- a/Tests/MountebankSwiftTests/Models/Stub/Response/Is/Is+initializersTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Response/Is/Is+initializersTests.swift
@@ -26,18 +26,21 @@ class IsInitializersTests: XCTestCase {
     }
 
     func testInitWithJsonEncodableBody() throws {
-        struct SomeCodableObject: Codable {
-            struct Bar: Codable {
-                let baz: String
-            }
-
-            let foo: String
-            let bar: Bar
-        }
-
-        let bodyJsonEncodable = SomeCodableObject(foo: "foo", bar: SomeCodableObject.Bar(baz: "baz"))
+        let bodyJsonEncodable = SomeCodableObject(
+            foo: "foo",
+            bar: SomeCodableObject.Bar(baz: "baz")
+        )
         let sut = Is(body: bodyJsonEncodable)
 
         XCTAssertEqual(sut.body, .jsonEncodable(bodyJsonEncodable))
     }
+}
+
+private struct SomeCodableObject: Equatable, Codable {
+    struct Bar: Equatable, Codable {
+        let baz: String
+    }
+
+    let foo: String
+    let bar: Bar
 }

--- a/Tests/MountebankSwiftTests/Models/Stub/Response/Is/IsTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Response/Is/IsTests.swift
@@ -101,7 +101,7 @@ class IsTests: XCTestCase {
                 "headers": [
                     "X-My-Invalid-header-type-should-be-string" : 42,
                     "X-Invalid-headers.." : "should be ignored",
-                ]
+                ],
             ],
             Is(
                 statusCode: 404,

--- a/Tests/MountebankSwiftTests/Models/Stub/StubTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/StubTests.swift
@@ -1,6 +1,7 @@
-import MountebankSwift
-
+import InlineSnapshotTesting
 import XCTest
+
+@testable import MountebankSwift
 
 final class StubTests: XCTestCase {
     func testText() throws {
@@ -78,5 +79,238 @@ final class StubTests: XCTestCase {
             Stub.Examples.noPredicates.json,
             Stub.Examples.noPredicates.value
         )
+    }
+
+    func testRecreatable() {
+        assertInlineSnapshot(
+            of: Stub.Examples.text.value.recreatable,
+            as: .lines
+        ) {
+            """
+            Stub(
+                response: Is(
+                    statusCode: 200,
+                    body: .text("Hello world")
+                ),
+                predicate: .equals(Request(path: "/text-200"))
+            )
+            """
+        }
+    }
+
+    // swiftlint:disable line_length
+    func testRecreatableAllStubs() {
+        assertInlineSnapshot(
+            of: Stub.Examples.all.map(\.value).recreatable,
+            as: .lines
+        ) {
+            #"""
+            [
+                Stub(
+                    response: Is(
+                        statusCode: 200,
+                        body: .text("Hello world")
+                    ),
+                    predicate: .equals(Request(path: "/text-200"))
+                ),
+                Stub(
+                    response: Is(
+                        statusCode: 200,
+                        headers: ["Content-Type": "application/json"],
+                        body: .json([
+                            "bikeId": 123.0,
+                            "name": "Turbo Bike 4000"
+                        ])
+                    ),
+                    predicate: .equals(Request(path: "/json-200"))
+                ),
+                Stub(
+                    response: Proxy(
+                        to: "https://www.somesite.com:3000",
+                        mode: .proxyAlways
+                    ),
+                    predicates: []
+                ),
+                Stub(
+                    response: Proxy(
+                        to: "https://www.somesite.com:3000",
+                        mode: .proxyAlways,
+                        addWaitBehavior: true,
+                        addDecorateBehavior: "(config) => { config.response.headers[\'X-Test-token\'] = Math.random() * 42; }"
+                    ),
+                    predicates: []
+                ),
+                Stub(
+                    response: Proxy(
+                        to: "https://www.somesite.com:3000",
+                        predicateGenerators: [
+                            .matches(
+                                fields: [
+                                    "method": true,
+                                    "path": true
+                                ],
+                                caseSensitive: true
+                            ),
+                            .matches(fields: ["query": [
+                                "category": true,
+                                "productId": true
+                            ]]),
+                            .matches(
+                                fields: [
+                                    "method": true,
+                                    "path": true,
+                                    "query": true
+                                ],
+                                predicateOperator: .deepEquals,
+                                caseSensitive: true,
+                                except: "!$",
+                                ignore: ["query": "startDate"]
+                            ),
+                            .matches(
+                                fields: ["body": true],
+                                jsonPath: JSONPath(selector: "$..number")
+                            ),
+                            .matches(
+                                fields: ["body": true],
+                                xPath: XPath(selector: "//number")
+                            ),
+                            .inject("    function (config) {\n        const predicate = {\n            exists: {\n                headers: {\n                    \'X-Transaction-Id\': false\n                }\n            }\n        };\n        if (config.request.headers[\'X-Transaction-Id\']) {\n            config.logger.debug(\'Requiring X-Transaction-Id header to exist in predicate\');\n            predicate.exists.headers[\'X-Transaction-Id\'] = true;\n        }\n        return [predicate];\n    }")
+                        ]
+                    ),
+                    predicates: []
+                ),
+                Stub(
+                    response: Is(
+                        statusCode: 200,
+                        body: .text("Hello world")
+                    ),
+                    predicates: []
+                ),
+                Stub(
+                    response: Is(statusCode: 404),
+                    predicate: .equals(Request(path: "/404"))
+                ),
+                Stub(
+                    responses: [
+                        Is(statusCode: 404),
+                        Is(
+                            statusCode: 200,
+                            body: .text("Hello world")
+                        )
+                    ],
+                    predicate: .equals(Request(path: "/404-to-200"))
+                ),
+                Stub(
+                    responses: [
+                        Is(
+                            statusCode: 200,
+                            body: .text("Hello world")
+                        ),
+                        Is(
+                            statusCode: 200,
+                            headers: ["Content-Type": "text/html"],
+                            body: .text("<html><body><h1>Who needs HTML?</h1></html>")
+                        ),
+                        Is(
+                            statusCode: 200,
+                            headers: ["Content-Type": "application/json"],
+                            body: .json([
+                                "bikeId": 123.0,
+                                "name": "Turbo Bike 4000"
+                            ])
+                        ),
+                        Is(
+                            statusCode: 200,
+                            body: .data(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAABaADAAQAAAABAAAABQAAAAB/qhzxAAAAKUlEQVQIHWP8//8/AwMjI5CAgv//wTyEAFScCaYAmcYhCDQDWRUDkA8AEGsMAtJaFngAAAAASUVORK5CYII=")!)
+                        ),
+                        Is(statusCode: 404),
+                        Proxy(
+                            to: "https://www.somesite.com:3000",
+                            mode: .proxyAlways
+                        ),
+                        Fault.connectionResetByPeer,
+                        Inject("(config) => { return { \"body\": \"hello world\" }; }")
+                    ],
+                    predicates: [
+                        .equals(Request(
+                            method: .put,
+                            path: "/test-is-200",
+                            query: ["key": [
+                                "first",
+                                "second"
+                            ]],
+                            headers: ["foo": "bar"],
+                            data: ["baz"]
+                        )),
+                        .deepEquals(Request(query: ["key": [
+                            "first",
+                            "second"
+                        ]])),
+                        .contains(Request(data: "AgM=")),
+                        .startsWith(Request(data: "first")),
+                        .endsWith(Request(data: "last")),
+                        .matches(Request(data: "^first")),
+                        .exists(Request(query: [
+                            "q": true,
+                            "search": false
+                        ])),
+                        .not(.equals(Request(
+                            method: .put,
+                            path: "/test-is-200",
+                            query: ["key": [
+                                "first",
+                                "second"
+                            ]],
+                            headers: ["foo": "bar"],
+                            data: ["baz"]
+                        ))),
+                        .or([
+                            .equals(Request(
+                                method: .put,
+                                path: "/test-is-200",
+                                query: ["key": [
+                                    "first",
+                                    "second"
+                                ]],
+                                headers: ["foo": "bar"],
+                                data: ["baz"]
+                            )),
+                            .contains(Request(data: "AgM="))
+                        ]),
+                        .and([
+                            .equals(Request(
+                                method: .put,
+                                path: "/test-is-200",
+                                query: ["key": [
+                                    "first",
+                                    "second"
+                                ]],
+                                headers: ["foo": "bar"],
+                                data: ["baz"]
+                            )),
+                            .deepEquals(Request(query: ["key": [
+                                "first",
+                                "second"
+                            ]]))
+                        ]),
+                        .inject("(config) => { return config.request.headers[\'Authorization\'] == \'Bearer <my-token>\'; }"),
+                        .equals(
+                            Request(path: "/with-parameters"),
+                            PredicateParameters(
+                                caseSensitive: true,
+                                except: "^The ",
+                                xPath: XPath(
+                                    selector: "//a:title",
+                                    namespace: ["a": "http://example.com/book"]
+                                ),
+                                jsonPath: JSONPath(selector: "$..title")
+                            )
+                        )
+                    ]
+                )
+            ]
+            """#
+        }
+        // swiftlint:enable line_length
     }
 }


### PR DESCRIPTION
This PR add Recreatables, for use with proxies.

Usage:

    // Create proxy
    let proxy = Stub(response: Proxy(
        to: "https://api.github.com",
        mode: .proxyAlways,
        predicateGenerators: [
            PredicateGenerator.matches(
                fields: ["path": true, "method": true]
            )
        ]
    ))
    let imposter = Imposter(networkProtocol: .http(), stubs: [proxy])
    let createdImposter = try await mountebank.postImposter(imposter: imposter)

    // Inject imposter in your app
    let imposterURL = mountebank
        .makeImposterUrl(port: createdImposter.port!)
        .absoluteString + "/"
    let app = XCUIApplication()
    app.launchArguments = ["-UITesting"]
    app.launchEnvironment = ["UITESTING_SERVER": imposterURL]
    app.launch()

    // Run the test/flows that you would like to perform
    ....

Then, write the generated stubs with predicates and responses to disk: 

    let imposters = try await mountebank.getAllImposters(replayable: true, removeProxies: true)
    for imposter in imposters {
        imposter.writeStubsToDisk()
    }

