### PR TITLE
Filter out invalid headers when decoding

### DIFF
--- a/Sources/MountebankSwift/Common/FailableDecodable.swift
+++ b/Sources/MountebankSwift/Common/FailableDecodable.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct FailableDecodable<Value : Decodable> : Decodable {
+    let value: Value?
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        do {
+            self.value = try container.decode(Value.self)
+        } catch {
+            print("[Mountebank]: ❌ Unable to decode \(decoder.codingPath.map(\.stringValue)) as \(Value.self)")
+            self.value = nil
+        }
+    }
+}
+
+struct FailableDictionaryDecodable<Key: Decodable & Hashable, Value : Decodable> : Decodable {
+    let value: [Key: Value]
+    init(from decoder: Decoder) throws {
+        value = try decoder
+            .singleValueContainer()
+            .decode([Key: FailableDecodable<Value>].self)
+            .reduce(into: [:], { partialResult, element in
+                if let value = element.value.value {
+                    partialResult[element.key] = value
+                }
+            })
+    }
+}

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest+Codable.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest+Codable.swift
@@ -35,7 +35,9 @@ extension Imposter.RecordedRequest {
         path = try container.decodeIfPresent(String.self, forKey: .path)
         query = try container.decodeIfPresent([String: String].self, forKey: .query)
 
-        headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
+        headers = try container.decodeIfPresent(
+            FailableDictionaryDecodable<String, String>.self, forKey: .headers
+        )?.value
         body = try container.decodeIfPresent(JSON.self, forKey: .body)
         form = try container.decodeIfPresent(JSON.self, forKey: .form)
 

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Imposter {
-    public struct RecordedRequest: Equatable, Codable, CustomDebugStringConvertible {
+    public struct RecordedRequest: Equatable, Codable {
         public let method: HTTPMethod?
         public let path: String?
         public let query: [String: String]?
@@ -33,12 +33,6 @@ extension Imposter {
             self.requestFrom = requestFrom
             self.ip = ip
             self.timestamp = timestamp
-        }
-
-        public var debugDescription: String {
-            [method.map(\.rawValue), path]
-                .compactMap { $0 }
-                .joined(separator: " ")
         }
     }
 }

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
@@ -26,7 +26,7 @@ public enum Body: Equatable {
             do {
                 return try (lhsEncoder ?? jsonEncoder).encode(lhs) == (rhsEncoder ?? jsonEncoder).encode(rhs)
             } catch {
-                print("Failed to encode object: \(error)")
+                print("[Mountebank]: ❌ Failed to encode object: \(error)")
                 return false
             }
         case (.text, _), (.json, _), (.jsonEncodable, _), (.data, _):

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is+Codable.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is+Codable.swift
@@ -50,7 +50,10 @@ extension Is: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         statusCode = try container.decode(Int.self, forKey: .statusCode)
-        headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
+        headers = try container.decodeIfPresent(
+            FailableDictionaryDecodable<String, String>.self,
+            forKey: .headers
+        )?.value
 
         let bodyMode = try container.decodeIfPresent(BodyMode.self, forKey: .mode)
 

--- a/Sources/MountebankSwift/Models/Stub/Stub+Codable.swift
+++ b/Sources/MountebankSwift/Models/Stub/Stub+Codable.swift
@@ -51,7 +51,7 @@ extension StubResponse {
             return .fault(response)
         }
 
-        print("❌ Unknown StubResponse \(type(of: self))")
+        print("[Mountebank]: ❌ Unknown StubResponse \(type(of: self))")
         return .is(Is(statusCode: 500, body: "❌ Unknown StubResponse \(type(of: self))"))
     }
 }

--- a/Tests/MountebankSwiftTests/Models/ImposterTests.swift
+++ b/Tests/MountebankSwiftTests/Models/ImposterTests.swift
@@ -67,4 +67,44 @@ final class ImposterTests: XCTestCase {
             Imposter.Examples.includingAllStubs.value
         )
     }
+
+    func testInvalidHeaders() throws {
+        try assertDecode(
+            [
+                "port": 123,
+                "protocol" : "http",
+                "stubs": [],
+                "numberOfRequests": 1,
+                "requests": [
+                    [
+                        "method": "GET",
+                        "path": "/test-path",
+                        "requestFrom": "127.0.0.1",
+                        "ip": "127.0.0.1",
+                        "timestamp": "2023-12-08T20:09:06.263Z",
+                        "headers": [
+                            "X-My-Invalid-header-type-should-be-string" : 42,
+                            "X-Invalid-headers.." : "should be ignored",
+                        ]
+                    ]
+                ]
+            ],
+            Imposter(
+                port: 123,
+                networkProtocol: .http(),
+                stubs: [],
+                numberOfRequests: 1,
+                requests: [
+                    Imposter.RecordedRequest(
+                        method: .get,
+                        path: "/test-path",
+                        headers: ["X-Invalid-headers.." : "should be ignored"],
+                        requestFrom: "127.0.0.1",
+                        ip: "127.0.0.1",
+                        timestamp: Date(timeIntervalSince1970: 1702066146.263)
+                    )
+                ]
+            )
+        )
+    }
 }

--- a/Tests/MountebankSwiftTests/Models/Stub/Response/Is/IsTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Response/Is/IsTests.swift
@@ -93,4 +93,20 @@ class IsTests: XCTestCase {
             Is.Examples.withResponseParameters.json
         )
     }
+
+    func testInvalidHeaders() throws {
+        try assertDecode(
+            [
+                "statusCode" : 404,
+                "headers": [
+                    "X-My-Invalid-header-type-should-be-string" : 42,
+                    "X-Invalid-headers.." : "should be ignored",
+                ]
+            ],
+            Is(
+                statusCode: 404,
+                headers: ["X-Invalid-headers.." : "should be ignored"]
+            )
+        )
+    }
 }


### PR DESCRIPTION
When I was testing Mountebank with PocketCasts I ran into recorded requests that contained an Int as a header value instead of a string. This caused the whole imposter to not be able to decode. 

This PR fixes that issue by filtering out invalid header fields when decoding 