### PR TITLE
Implement Sendable where possible in preperation of swift 6.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,11 @@ let package = Package(
     targets: [
         .target(
             name: "MountebankSwift",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: [
+                // Enable to validate if project is compatible with swift 6.0 Concurrency
+                // .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(
             name: "MountebankSwiftTests",
@@ -35,6 +39,10 @@ let package = Package(
             ],
             resources: [
                 .copy("ExampleData/Files"),
+            ],
+            swiftSettings: [
+                // Enable to validate if project is compatible with swift 6.0 Concurrency
+                // .enableExperimentalFeature("StrictConcurrency")
             ]
         ),
     ]

--- a/Sources/MountebankSwift/Api/Endpoint/Parameters/EndpointParameters.swift
+++ b/Sources/MountebankSwift/Api/Endpoint/Parameters/EndpointParameters.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol EndpointParameters {
+public protocol EndpointParameters: Sendable {
     func makeQueryParameters() -> [URLQueryItem]
 }
 

--- a/Sources/MountebankSwift/Api/Host.swift
+++ b/Sources/MountebankSwift/Api/Host.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Host of the Mountebank server
-public enum Host {
+public enum Host: Sendable {
     public typealias RawValue = String
     case localhost
     case custom(String)

--- a/Sources/MountebankSwift/Api/MountebankErrors.swift
+++ b/Sources/MountebankSwift/Api/MountebankErrors.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Error that the Mountebank server will return if something did go wrong.
 public struct MountebankErrors: Codable, Equatable, Error {
-    public struct MountebankError: Codable, Equatable {
+    public struct MountebankError: Codable, Equatable, Sendable {
         public let code: String
         public let message: String?
         public let errno: Int?

--- a/Sources/MountebankSwift/Common/HTTPMethod.swift
+++ b/Sources/MountebankSwift/Common/HTTPMethod.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A  HTTP request method
-public enum HTTPMethod: String, Codable, Equatable {
+public enum HTTPMethod: String, Codable, Equatable, Sendable {
     case get = "GET"
     case head = "HEAD"
     case post = "POST"

--- a/Sources/MountebankSwift/Common/JSON.swift
+++ b/Sources/MountebankSwift/Common/JSON.swift
@@ -35,7 +35,7 @@ private let prettyPrintingJSONEncoder: JSONEncoder = {
 ///
 /// From  [github.com/iwill/generic-json-swift](https://github.com/iwill/generic-json-swift/)
 @dynamicMemberLookup
-public enum JSON: Codable, Hashable {
+public enum JSON: Codable, Hashable, Sendable {
     case string(String)
     case number(Double)
     case object([String: JSON])

--- a/Sources/MountebankSwift/HttpClient/HttpClient.swift
+++ b/Sources/MountebankSwift/HttpClient/HttpClient.swift
@@ -3,7 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-protocol HttpClientProtocol {
+protocol HttpClientProtocol: Sendable {
     func httpRequest(_ request: HTTPRequest) async throws -> HTTPResponse
 }
 

--- a/Sources/MountebankSwift/HttpClient/HttpError.swift
+++ b/Sources/MountebankSwift/HttpClient/HttpError.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-enum HttpError: Error {
+enum HttpError: Error, Sendable {
     case requestFailed
 }

--- a/Sources/MountebankSwift/Models/Config/Config.swift
+++ b/Sources/MountebankSwift/Models/Config/Config.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Configuration of the Mountebank server
 ///
 /// [mbtest.org/docs/api/contracts?type=config](https://www.mbtest.org/docs/api/contracts?type=config)
-public struct Config: Codable, Equatable {
-    public struct Options: Codable, Equatable {
-        public struct Log: Codable, Equatable {
+public struct Config: Codable, Equatable, Sendable {
+    public struct Options: Codable, Equatable, Sendable {
+        public struct Log: Codable, Equatable, Sendable {
             let level: LogLevel
         }
 
@@ -71,9 +71,9 @@ public struct Config: Codable, Equatable {
         public let debug: Bool
     }
 
-    public struct Process: Codable, Equatable {
+    public struct Process: Codable, Equatable, Sendable {
 
-        /// The version of node.js which Mountebank is useing
+        /// The version of Nodejs which Mountebank is using
         public let nodeVersion: String
 
         /// The architecture of the machine running Mountebank.

--- a/Sources/MountebankSwift/Models/Config/LogLevel.swift
+++ b/Sources/MountebankSwift/Models/Config/LogLevel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The log level of a log entry
-public enum LogLevel: String, Codable {
+public enum LogLevel: String, Codable, Sendable {
     case info
     case warn
     case error

--- a/Sources/MountebankSwift/Models/Config/Logs.swift
+++ b/Sources/MountebankSwift/Models/Config/Logs.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Logs of the mountebank server
 ///
 /// [mbtest.org/docs/api/contracts?type=logs](https://www.mbtest.org/docs/api/contracts?type=logs)
-public struct Logs: Codable, Equatable {
+public struct Logs: Codable, Equatable, Sendable {
 
-    public struct Log: Codable, Equatable {
+    public struct Log: Codable, Equatable, Sendable {
         public let level: LogLevel
         public let message: String
         public let timestamp: Date?

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.RecordedRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Imposter {
-    public struct RecordedRequest: Equatable, Codable {
+    public struct RecordedRequest: Equatable, Codable, Sendable {
         public let method: HTTPMethod?
         public let path: String?
         public let query: [String: String]?

--- a/Sources/MountebankSwift/Models/Imposter/Imposter.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.swift
@@ -7,13 +7,13 @@ import Foundation
 /// and stop an imposter during test teardown.
 ///
 /// [mbtest.org/docs/api/contracts?type=imposter](https://www.mbtest.org/docs/api/contracts?type=imposter)
-public struct Imposter: Codable, Equatable {
+public struct Imposter: Codable, Equatable, Sendable {
 
     /// Mountebank does also support `tcp`, `smtp` and custom protocols
     /// implemented in community plugins.
     ///
     /// Please submit a feature request issue on Github for support if you need other protocols
-    public enum NetworkProtocol: Codable, Equatable {
+    public enum NetworkProtocol: Codable, Equatable, Sendable {
         /// Options for the http protocol
         ///
         /// [mbtest.org/docs/protocols/http](https://www.mbtest.org/docs/protocols/http)

--- a/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/JSONPath.swift
@@ -4,7 +4,7 @@ import Foundation
 /// much like the except parameter.
 ///
 /// [mbtest.org/docs/api/jsonpath](https://www.mbtest.org/docs/api/jsonpath)
-public struct JSONPath: Codable, Equatable {
+public struct JSONPath: Codable, Equatable, Sendable {
     /// The JSONPath selector
     public let selector: String
 

--- a/Sources/MountebankSwift/Models/Stub/Predicate/Predicate.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/Predicate.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Predicates are added to a stub in an array, and all predicates are AND'd together.
 ///
 /// [mbtest.org/docs/api/predicates](https://www.mbtest.org/docs/api/predicates)
-public indirect enum Predicate: Equatable {
+public indirect enum Predicate: Equatable, Sendable {
     /// The request field matches the predicate
     /// [mbtest.org/docs/api/predicates#predicates-equals](https://www.mbtest.org/docs/api/predicates#predicates-equals)
     case equals(Request, PredicateParameters? = nil)

--- a/Sources/MountebankSwift/Models/Stub/Predicate/PredicateParameters.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/PredicateParameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Parameters that can be added to a ``Predicate`` to finetune it
-public struct PredicateParameters: Equatable {
+/// Parameters that can be added to a ``Predicate`` to fine-tune it
+public struct PredicateParameters: Equatable, Sendable {
     /// Determines if the match is case sensitive or not.
     /// This includes keys for objects such as query parameters.
     let caseSensitive: Bool?

--- a/Sources/MountebankSwift/Models/Stub/Predicate/Request.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/Request.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The predicate will use all the optional fields in this request to try to match an incoming request made by the
 /// application under test
-public struct Request: Equatable, Codable {
+public struct Request: Equatable, Codable, CustomDebugStringConvertible, Sendable {
     public let method: HTTPMethod?
     public let path: String?
     public let query: [String: JSON]?

--- a/Sources/MountebankSwift/Models/Stub/Predicate/XPath.swift
+++ b/Sources/MountebankSwift/Models/Stub/Predicate/XPath.swift
@@ -4,7 +4,7 @@ import Foundation
 /// much like the except parameter.
 ///
 /// [mbtest.org/docs/api/xpath](https://www.mbtest.org/docs/api/xpath)
-public struct XPath: Codable, Equatable {
+public struct XPath: Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case selector
         case namespace = "ns"

--- a/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.BehaviorCopyMethod.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.BehaviorCopyMethod.swift
@@ -2,8 +2,8 @@ import Foundation
 
 extension Behavior {
     /// The method used to select values from the request.
-    public enum BehaviorCopyMethod: Equatable, Codable {
-        public struct Options: OptionSet, Equatable, Codable {
+    public enum BehaviorCopyMethod: Equatable, Codable, Sendable {
+        public struct Options: OptionSet, Equatable, Codable, Sendable {
             public let rawValue: UInt
 
             public init(rawValue: UInt) {

--- a/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Behavior/Behavior.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Behaviors act as a middleware pipeline of transformations to alter the created response of a stub.
 ///
 /// [mbtest.org/docs/api/behaviors](https://www.mbtest.org/docs/api/behaviors)
-public enum Behavior: Equatable {
+public enum Behavior: Equatable, Sendable {
 
     /// Adds latency to a response by waiting a specified number of milliseconds before sending the response.
     case wait(miliseconds: Int)

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Body.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 /// A body for an ``Is`` response
-public enum Body: Equatable {
+public enum Body: Equatable, Sendable {
+    public typealias JsonEncodable = Encodable & Sendable
+    
     case text(String)
     /// A JSON body that will be encoded to a text response
     case json(JSON)
     /// An Encodable body that will be encoded to a text response
     /// Custom encoding strategies are supported by providing a custom JSONEncoder
-    case jsonEncodable(Encodable, JSONEncoder? = nil)
+    case jsonEncodable(JsonEncodable, JSONEncoder? = nil)
     /// A Data response that will be base64 encoded
     case data(Data)
 

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is+initializers.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is+initializers.swift
@@ -52,7 +52,7 @@ extension Is {
     public init(
         statusCode: Int = 200,
         headers: [String: String]? = nil,
-        body: any Codable,
+        body: any Codable & Sendable,
         encoder: JSONEncoder? = nil,
         parameters: ResponseParameters? = nil
     ) {
@@ -139,7 +139,7 @@ extension Array where Element == Is {
     public init(
         statusCode: Int = 200,
         headers: [String: String]? = nil,
-        bodies: [any Codable],
+        bodies: [any Codable & Sendable],
         parameters: ResponseParameters
     ) {
         self = bodies.map { body in

--- a/Sources/MountebankSwift/Models/Stub/Response/Is/Is.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Is/Is.swift
@@ -3,8 +3,9 @@ import Foundation
 // swiftlint:disable type_name
 /// A regular predefined response. Merges the specified response fields with ``Imposter``.`defaultResponse`
 public struct Is: StubResponse, Equatable {
-    public static var defaultBehaviors: [Behavior] = []
-    public static var defaultHeaders: [String: String] = [:]
+    
+    public private(set) static var defaultBehaviors: [Behavior] = []
+    public private(set) static var defaultHeaders: [String: String] = [:]
 
     public let statusCode: Int?
     public let headers: [String: String]?
@@ -28,7 +29,7 @@ public struct Is: StubResponse, Equatable {
         _ headers: [String: String]?,
         body: Body?
     ) -> [String: String]? {
-        var result = Self.defaultHeaders
+        var result = defaultHeaders
 
         switch body {
         case .none, .text, .data:

--- a/Sources/MountebankSwift/Models/Stub/Response/Proxy/PredicateGenerator.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Proxy/PredicateGenerator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum PredicateOperator: String, Codable {
+public enum PredicateOperator: String, Codable, Sendable {
     case exists
     case equals
     case deepEquals
@@ -10,7 +10,7 @@ public enum PredicateOperator: String, Codable {
     case matches
 }
 
-public enum PredicateGenerator: Equatable {
+public enum PredicateGenerator: Equatable, Sendable {
     /// Defines a template for the generated predicates
     /// [mbtest.org/docs/api/proxies#proxy-predicate-generators](https://www.mbtest.org/docs/api/proxies#proxy-predicate-generators)
     /// - Parameters:

--- a/Sources/MountebankSwift/Models/Stub/Response/Proxy/Proxy.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/Proxy/Proxy.swift
@@ -3,9 +3,9 @@ import Foundation
 /// A proxy response proxies the request to the specified destination and returns the response.
 ///
 /// [mbtest.org/docs/api/proxies](https://www.mbtest.org/docs/api/proxies)
-public struct Proxy: StubResponse, Codable, Equatable {
+public struct Proxy: StubResponse, Codable, Equatable, Sendable {
     /// Replay behavior of the proxy.
-    public enum Mode: String, Codable {
+    public enum Mode: String, Codable, Sendable {
         /// proxyOnce mode doesn't require you to explicitly do anything to replay the proxied responses.
         case proxyOnce
         /// The proxyAlways mode requires you to run the mb replay command (or equivalent) to
@@ -16,7 +16,7 @@ public struct Proxy: StubResponse, Codable, Equatable {
     }
 
     /// Protocol specific parameters for this proxy
-    public enum NetworkProtocolParameters: Equatable {
+    public enum NetworkProtocolParameters: Equatable, Sendable {
         /// [mbtest.org/docs/api/proxies](https://www.mbtest.org/docs/api/proxies)
         /// - Parameters:
         ///   - injectHeaders: Key-value pairs of headers to inject into the proxied request.

--- a/Sources/MountebankSwift/Models/Stub/Response/ResponseParameters.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/ResponseParameters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Parameters that can be added to a response  to finetune it.
-public struct ResponseParameters: Equatable {
+/// Parameters that can be added to a response to fine-tune it.
+public struct ResponseParameters: Equatable, Sendable {
     /// Repeats the response the given number of times.
     public let repeatCount: Int?
     public let behaviors: [Behavior]?

--- a/Sources/MountebankSwift/Models/Stub/Response/StubResponse.swift
+++ b/Sources/MountebankSwift/Models/Stub/Response/StubResponse.swift
@@ -2,4 +2,4 @@ import Foundation
 
 /// Empty protocol for easier usage of the Stub api.
 /// The following symbols conform: ``Is``, ``Proxy``, ``Inject`` and ``Fault``
-public protocol StubResponse: Codable, Equatable {}
+public protocol StubResponse: Codable, Equatable, Sendable {}

--- a/Sources/MountebankSwift/Models/Stub/Stub.swift
+++ b/Sources/MountebankSwift/Models/Stub/Stub.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Every time the stub is used it will return the next response in the list of its responses.
 ///
 /// [mbtest.org/docs/api/contracts?type=stub](https://www.mbtest.org/docs/api/contracts?type=stub)
-public struct Stub: Equatable {
+public struct Stub: Equatable, Sendable {
     /// In the absence of a predicate, a stub always matches, and there's never a reason to add more than one stub to
     /// an imposter. Predicates allow imposters to have much richer behavior by defining whether or not a stub matches
     /// a request. When multiple stubs are created on an imposter, the first stub that matches is selected.
@@ -65,9 +65,8 @@ extension Stub: Recreatable {
     }
 
     private var responseProperty: (String, Recreatable) {
-        if responses.count == 1 {
-            // swiftlint:disable:next force_unwrapping
-            switch responses.first!.codable {
+        if responses.count == 1, let codable = responses.first?.codable {
+            switch codable {
             case .is(let response):
                 return ("response", response)
             case .proxy(let response):

--- a/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
+++ b/Tests/MountebankSwiftTests/Api/MountebankIntegrationTests.swift
@@ -224,7 +224,7 @@ final class MountebankIntegrationTests: XCTestCase {
 
     // Use this test to verify in your browser that all these content types are encoded properly
     // Put a breakpoint after the `postImposter` call and check for example http://localhost:1234/sample.png
-    func testDiffentResponseBodyTypes() async throws {
+    func testDifferentResponseBodyTypes() async throws {
         let sampleFiles = [
             SampleFile.png,
             SampleFile.jpg,

--- a/Tests/MountebankSwiftTests/ExampleData/Example.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Example.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MountebankSwift
 
-struct Example<CodableEquatableType: Codable & Equatable> {
+struct Example<CodableEquatableType: Codable & Equatable & Sendable> {
     let value: CodableEquatableType
     let json: JSON
 }


### PR DESCRIPTION
With swift 5.10 it is already possible to check your project for Strict Concurrency with `.enableExperimentalFeature("StrictConcurrency")`. This pr does fix the most issues.