### PR TITLE
Set default argument for Imposter.networkProtocol

### DIFF
--- a/Sources/MountebankSwift/Models/Imposter/Imposter.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter.swift
@@ -102,7 +102,7 @@ public struct Imposter: Codable, Equatable {
     ///   - recordRequests: If set to true, the server will record requests received, for mock verification purposes.
     public init(
         port: Int? = nil,
-        networkProtocol: NetworkProtocol,
+        networkProtocol: NetworkProtocol = .http(),
         name: String? = nil,
         stubs: [Stub],
         defaultResponse: Is? = nil,

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
@@ -17,7 +17,6 @@ extension Imposter {
         static let simple = Example(
             value: Imposter(
                 port: 19190,
-                networkProtocol: .http(),
                 stubs: [Stub.Examples.text.value]
             ),
             json: [
@@ -30,7 +29,6 @@ extension Imposter {
         static let json = Example(
             value: Imposter(
                 port: 100,
-                networkProtocol: .http(),
                 stubs: [Stub.Examples.json.value]
             ),
             json: [
@@ -158,7 +156,6 @@ extension Imposter {
         static let includingAllStubs = Example(
             value: Imposter(
                 port: 8080,
-                networkProtocol: .http(),
                 name: "Single stub",
                 stubs: Stub.Examples.all.map(\.value),
                 defaultResponse: Is(statusCode: 403),
@@ -177,7 +174,6 @@ extension Imposter {
         static let simpleRecordRequests = Example(
             value: Imposter(
                 port: 19190,
-                networkProtocol: .http(),
                 stubs: [Stub.Examples.text.value],
                 recordRequests: true
             ),

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposters+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposters+Examples.swift
@@ -5,7 +5,7 @@ extension Imposters {
     enum Examples {
         static let single = Example(
             value: Imposters(imposters: [
-                Imposter(port: 3535, networkProtocol: .http(), stubs: []),
+                Imposter(port: 3535, stubs: []),
             ]),
             json: [
                 "imposters": [


### PR DESCRIPTION
I think `.http()` would be used in a lot of cases, so lets just default it. 