### PR TITLE
Write stubs to disk into extension

### DIFF
--- a/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
+++ b/Sources/MountebankSwift/Models/Imposter/Imposter+writeStubsToDisk.swift
@@ -17,11 +17,10 @@ extension Imposter {
         let propertyName = [
             sansanitisedMethod,
             "Stubs",
-            name.map { sanitizeName($0).capitalized }
+            name.map { sanitizeName($0).capitalized },
         ]
-            .compactMap { $0 }
-            .joined()
-
+        .compactMap { $0 }
+        .joined()
 
         increaseRecreatableIndent()
         let stubsString = stubs.recreatable
@@ -35,6 +34,7 @@ extension Imposter {
         extension \(dirName) {
             static let \(propertyName): [Stub] = \(stubsString)
         }
+
         // swiftlint:enable line_length force_unwrapping
         """
 

--- a/Sources/MountebankSwift/Models/Recreatable.swift
+++ b/Sources/MountebankSwift/Models/Recreatable.swift
@@ -13,6 +13,8 @@ protocol Recreatable {
 private let delimiter = ",\n"
 private let whitespace = "    "
 private var indent = 0
+func increaseRecreatableIndent() { indent += 1 }
+func decreaseRecreatableIndent() { indent -= 1 }
 
 extension Recreatable {
     /// Helper to create a recreatable string for a struct

--- a/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Imposter/Imposter+Examples.swift
@@ -156,7 +156,7 @@ extension Imposter {
         static let includingAllStubs = Example(
             value: Imposter(
                 port: 8080,
-                name: "Single stub",
+                name: "all",
                 stubs: Stub.Examples.all.map(\.value),
                 defaultResponse: Is(statusCode: 403),
                 recordRequests: true
@@ -164,7 +164,7 @@ extension Imposter {
             json: [
                 "port": 8080,
                 "protocol": "http",
-                "name": "Single stub",
+                "name": "all",
                 "stubs": .array(Stub.Examples.all.map(\.json)),
                 "defaultResponse": ["statusCode": 403],
                 "recordRequests": true,

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/AddStub+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/AddStub+Examples.swift
@@ -7,7 +7,7 @@ extension AddStub {
             value: AddStub(
                 index: 1,
                 stub: Stub(
-                    responses: [Inject.Examples.injectBody.value],
+                    responses: [Inject.Examples.injectBodySingleLine.value],
                     predicates: [Predicate.Examples.equals.value]
                 )
             ),
@@ -15,7 +15,7 @@ extension AddStub {
                 "index": 1,
                 "stub": [
                     "responses": [
-                        ["inject": Inject.Examples.injectBody.json],
+                        ["inject": Inject.Examples.injectBodySingleLine.json],
                     ],
                     "predicates": [Predicate.Examples.equals.json],
                 ],

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Inject+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Response/Inject+Examples.swift
@@ -3,11 +3,18 @@ import MountebankSwift
 
 extension Inject {
     enum Examples {
-        static let injectBody = Example(
-            value: Inject(
-                "(config) => { return { \"body\": \"hello world\" }; }"
-            ),
+        static let injectBodySingleLine = Example(
+            value: Inject("(config) => { return { \"body\": \"hello world\" }; }"),
             json: "(config) => { return { \"body\": \"hello world\" }; }"
+        )
+
+        static let injectBodyMultiline = Example(
+            value: Inject("""
+            (config) => {
+                return { \"body\": \"hello world\" };
+            }
+            """),
+            json: "(config) => {\n    return { \"body\": \"hello world\" };\n}"
         )
     }
 }

--- a/Tests/MountebankSwiftTests/ExampleData/Stub/Stub+Examples.swift
+++ b/Tests/MountebankSwiftTests/ExampleData/Stub/Stub+Examples.swift
@@ -11,6 +11,7 @@ extension Stub {
             predicateGeneratorsProxy,
             noPredicates,
             http404,
+            injections,
             textWhenRefresh404,
             multiplePredicatesAndResponses,
         ]
@@ -70,6 +71,25 @@ extension Stub {
             ]
         )
 
+        static let injections = Example(
+            value: Stub(
+                responses: [
+                    Inject.Examples.injectBodySingleLine.value,
+                    Inject.Examples.injectBodyMultiline.value,
+                ],
+                predicate: Predicate.equals(Request(path: "/injection"))
+            ),
+            json: [
+                "responses": [
+                    ["inject": Inject.Examples.injectBodySingleLine.json],
+                    ["inject": Inject.Examples.injectBodyMultiline.json],
+                ],
+                "predicates": [
+                    ["equals" : ["path": "/injection"]],
+                ],
+            ]
+        )
+
         static let simpleProxy = Example(
             value: Stub(
                 response: Proxy.Examples.simple.value
@@ -104,7 +124,7 @@ extension Stub {
                     [
                         Proxy.Examples.simple.value,
                         Fault.Examples.connectionResetByPeer.value,
-                        Inject.Examples.injectBody.value,
+                        Inject.Examples.injectBodySingleLine.value,
                     ]
                 ,
                 predicates: Predicate.Examples.all.map(\.value)
@@ -117,7 +137,7 @@ extension Stub {
                         [
                             ["proxy": Proxy.Examples.simple.json],
                             ["fault": Fault.Examples.connectionResetByPeer.json],
-                            ["inject": Inject.Examples.injectBody.json],
+                            ["inject": Inject.Examples.injectBodySingleLine.json],
                         ]
                 ),
                 "predicates": .array(Predicate.Examples.all.map(\.json)),

--- a/Tests/MountebankSwiftTests/Models/RecreatableTests.swift
+++ b/Tests/MountebankSwiftTests/Models/RecreatableTests.swift
@@ -77,7 +77,9 @@ final class RecreatableTests: XCTestCase {
         let data: Data = stringValue.data(using: .utf8)!
         assertInlineSnapshot(of: data.recreatable, as: .lines) {
             """
-            Data(base64Encoded: "c29tZS1zdHJpbmc=")!
+            Data(
+                base64Encoded: "c29tZS1zdHJpbmc="
+            )!
             """
         }
         XCTAssertEqual(
@@ -124,7 +126,7 @@ final class RecreatableTests: XCTestCase {
                 bar: [
                     42,
                     4,
-                    2
+                    2,
                 ],
                 enumValue: .namedAssociatedValues(
                     foo: "aa",
@@ -158,7 +160,7 @@ final class RecreatableTests: XCTestCase {
                 bar: [
                     42,
                     4,
-                    2
+                    2,
                 ],
                 enumValue: .structValue(structValue: MyStruct(
                     foo: "foo",
@@ -201,7 +203,7 @@ final class RecreatableTests: XCTestCase {
                 "array": [
                     "foo",
                     "bar",
-                    "baz"
+                    "baz",
                 ],
                 "bool": true,
                 "dictionary": [
@@ -210,15 +212,15 @@ final class RecreatableTests: XCTestCase {
                         "bool": true,
                         "double": 42.0,
                         "int": 42,
-                        "string": "value"
+                        "string": "value",
                     ],
                     "double": 42.0,
                     "int": 42,
-                    "string": "value"
+                    "string": "value",
                 ],
                 "double": 42.0,
                 "int": 42,
-                "string": "value"
+                "string": "value",
             ]
             """
         }
@@ -230,7 +232,7 @@ final class RecreatableTests: XCTestCase {
             [
                 "foo",
                 "bar",
-                "baz"
+                "baz",
             ]
             """
         }
@@ -242,7 +244,7 @@ final class RecreatableTests: XCTestCase {
             [
                 "",
                 "second",
-                "first"
+                "first",
             ]
             """
         }
@@ -297,15 +299,15 @@ final class RecreatableTests: XCTestCase {
                     "dictionary": [
                         "array": [
                             "foo",
-                            "bar"
+                            "bar",
                         ],
                         "bool": true,
                         "double": 42.0,
                         "nested": ["query": true],
-                        "null": .null
+                        "null": .null,
                     ],
                     "int": 42.0,
-                    "string": "value"
+                    "string": "value",
                 ]
             )
             """

--- a/Tests/MountebankSwiftTests/Models/Stub/Response/InjectTests.swift
+++ b/Tests/MountebankSwiftTests/Models/Stub/Response/InjectTests.swift
@@ -3,14 +3,25 @@ import MountebankSwift
 import XCTest
 
 final class InjectTests: XCTestCase {
-    func testInjectBody() throws {
+    func testInjectBodySingleLine() throws {
         try assertEncode(
-            Inject.Examples.injectBody.value,
-            Inject.Examples.injectBody.json
+            Inject.Examples.injectBodySingleLine.value,
+            Inject.Examples.injectBodySingleLine.json
         )
         try assertDecode(
-            Inject.Examples.injectBody.json,
-            Inject.Examples.injectBody.value
+            Inject.Examples.injectBodySingleLine.json,
+            Inject.Examples.injectBodySingleLine.value
+        )
+    }
+
+    func testInjectBodyMultiline() throws {
+        try assertEncode(
+            Inject.Examples.injectBodyMultiline.value,
+            Inject.Examples.injectBodyMultiline.json
+        )
+        try assertDecode(
+            Inject.Examples.injectBodyMultiline.json,
+            Inject.Examples.injectBodyMultiline.value
         )
     }
 }

--- a/Tests/MountebankSwiftTests/Models/__Imposters__/ImposterTests/testWriteToDisk.stubs.all.swift
+++ b/Tests/MountebankSwiftTests/Models/__Imposters__/ImposterTests/testWriteToDisk.stubs.all.swift
@@ -17,7 +17,7 @@ extension ImposterTests {
                 headers: ["Content-Type": "application/json"],
                 body: .json([
                     "bikeId": 123.0,
-                    "name": "Turbo Bike 4000"
+                    "name": "Turbo Bike 4000",
                 ])
             ),
             predicate: .equals(Request(path: "/json-200"))
@@ -45,19 +45,19 @@ extension ImposterTests {
                     .matches(
                         fields: [
                             "method": true,
-                            "path": true
+                            "path": true,
                         ],
                         caseSensitive: true
                     ),
                     .matches(fields: ["query": [
                         "category": true,
-                        "productId": true
+                        "productId": true,
                     ]]),
                     .matches(
                         fields: [
                             "method": true,
                             "path": true,
-                            "query": true
+                            "query": true,
                         ],
                         predicateOperator: .deepEquals,
                         caseSensitive: true,
@@ -72,7 +72,22 @@ extension ImposterTests {
                         fields: ["body": true],
                         xPath: XPath(selector: "//number")
                     ),
-                    .inject("    function (config) {\n        const predicate = {\n            exists: {\n                headers: {\n                    \'X-Transaction-Id\': false\n                }\n            }\n        };\n        if (config.request.headers[\'X-Transaction-Id\']) {\n            config.logger.debug(\'Requiring X-Transaction-Id header to exist in predicate\');\n            predicate.exists.headers[\'X-Transaction-Id\'] = true;\n        }\n        return [predicate];\n    }")
+                    .inject("""
+                        function (config) {
+                            const predicate = {
+                                exists: {
+                                    headers: {
+                                        'X-Transaction-Id': false
+                                    }
+                                }
+                            };
+                            if (config.request.headers['X-Transaction-Id']) {
+                                config.logger.debug('Requiring X-Transaction-Id header to exist in predicate');
+                                predicate.exists.headers['X-Transaction-Id'] = true;
+                            }
+                            return [predicate];
+                        }
+                    """),
                 ]
             ),
             predicates: []
@@ -90,11 +105,22 @@ extension ImposterTests {
         ),
         Stub(
             responses: [
+                Inject("(config) => { return { \"body\": \"hello world\" }; }"),
+                Inject("""
+                (config) => {
+                    return { "body": "hello world" };
+                }
+                """),
+            ],
+            predicate: .equals(Request(path: "/injection"))
+        ),
+        Stub(
+            responses: [
                 Is(statusCode: 404),
                 Is(
                     statusCode: 200,
                     body: .text("Hello world")
-                )
+                ),
             ],
             predicate: .equals(Request(path: "/404-to-200"))
         ),
@@ -114,12 +140,14 @@ extension ImposterTests {
                     headers: ["Content-Type": "application/json"],
                     body: .json([
                         "bikeId": 123.0,
-                        "name": "Turbo Bike 4000"
+                        "name": "Turbo Bike 4000",
                     ])
                 ),
                 Is(
                     statusCode: 200,
-                    body: .data(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAABaADAAQAAAABAAAABQAAAAB/qhzxAAAAKUlEQVQIHWP8//8/AwMjI5CAgv//wTyEAFScCaYAmcYhCDQDWRUDkA8AEGsMAtJaFngAAAAASUVORK5CYII=")!)
+                    body: .data(Data(
+                        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAABaADAAQAAAABAAAABQAAAAB/qhzxAAAAKUlEQVQIHWP8//8/AwMjI5CAgv//wTyEAFScCaYAmcYhCDQDWRUDkA8AEGsMAtJaFngAAAAASUVORK5CYII="
+                    )!)
                 ),
                 Is(statusCode: 404),
                 Proxy(
@@ -127,7 +155,7 @@ extension ImposterTests {
                     mode: .proxyAlways
                 ),
                 Fault.connectionResetByPeer,
-                Inject("(config) => { return { \"body\": \"hello world\" }; }")
+                Inject("(config) => { return { \"body\": \"hello world\" }; }"),
             ],
             predicates: [
                 .equals(Request(
@@ -135,14 +163,14 @@ extension ImposterTests {
                     path: "/test-is-200",
                     query: ["key": [
                         "first",
-                        "second"
+                        "second",
                     ]],
                     headers: ["foo": "bar"],
                     data: ["baz"]
                 )),
                 .deepEquals(Request(query: ["key": [
                     "first",
-                    "second"
+                    "second",
                 ]])),
                 .contains(Request(data: "AgM=")),
                 .startsWith(Request(data: "first")),
@@ -150,14 +178,14 @@ extension ImposterTests {
                 .matches(Request(data: "^first")),
                 .exists(Request(query: [
                     "q": true,
-                    "search": false
+                    "search": false,
                 ])),
                 .not(.equals(Request(
                     method: .put,
                     path: "/test-is-200",
                     query: ["key": [
                         "first",
-                        "second"
+                        "second",
                     ]],
                     headers: ["foo": "bar"],
                     data: ["baz"]
@@ -168,12 +196,12 @@ extension ImposterTests {
                         path: "/test-is-200",
                         query: ["key": [
                             "first",
-                            "second"
+                            "second",
                         ]],
                         headers: ["foo": "bar"],
                         data: ["baz"]
                     )),
-                    .contains(Request(data: "AgM="))
+                    .contains(Request(data: "AgM=")),
                 ]),
                 .and([
                     .equals(Request(
@@ -181,15 +209,15 @@ extension ImposterTests {
                         path: "/test-is-200",
                         query: ["key": [
                             "first",
-                            "second"
+                            "second",
                         ]],
                         headers: ["foo": "bar"],
                         data: ["baz"]
                     )),
                     .deepEquals(Request(query: ["key": [
                         "first",
-                        "second"
-                    ]]))
+                        "second",
+                    ]])),
                 ]),
                 .inject("(config) => { return config.request.headers[\'Authorization\'] == \'Bearer <my-token>\'; }"),
                 .equals(
@@ -203,9 +231,10 @@ extension ImposterTests {
                         ),
                         jsonPath: JSONPath(selector: "$..title")
                     )
-                )
+                ),
             ]
-        )
+        ),
     ]
 }
+
 // swiftlint:enable line_length force_unwrapping

--- a/Tests/MountebankSwiftTests/Models/__Imposters__/ImposterTests/testWriteToDisk.stubs.all.swift
+++ b/Tests/MountebankSwiftTests/Models/__Imposters__/ImposterTests/testWriteToDisk.stubs.all.swift
@@ -1,0 +1,211 @@
+import Foundation
+import MountebankSwift
+
+// swiftlint:disable line_length force_unwrapping
+extension ImposterTests {
+    static let testWriteToDiskStubsAll: [Stub] = [
+        Stub(
+            response: Is(
+                statusCode: 200,
+                body: .text("Hello world")
+            ),
+            predicate: .equals(Request(path: "/text-200"))
+        ),
+        Stub(
+            response: Is(
+                statusCode: 200,
+                headers: ["Content-Type": "application/json"],
+                body: .json([
+                    "bikeId": 123.0,
+                    "name": "Turbo Bike 4000"
+                ])
+            ),
+            predicate: .equals(Request(path: "/json-200"))
+        ),
+        Stub(
+            response: Proxy(
+                to: "https://www.somesite.com:3000",
+                mode: .proxyAlways
+            ),
+            predicates: []
+        ),
+        Stub(
+            response: Proxy(
+                to: "https://www.somesite.com:3000",
+                mode: .proxyAlways,
+                addWaitBehavior: true,
+                addDecorateBehavior: "(config) => { config.response.headers[\'X-Test-token\'] = Math.random() * 42; }"
+            ),
+            predicates: []
+        ),
+        Stub(
+            response: Proxy(
+                to: "https://www.somesite.com:3000",
+                predicateGenerators: [
+                    .matches(
+                        fields: [
+                            "method": true,
+                            "path": true
+                        ],
+                        caseSensitive: true
+                    ),
+                    .matches(fields: ["query": [
+                        "category": true,
+                        "productId": true
+                    ]]),
+                    .matches(
+                        fields: [
+                            "method": true,
+                            "path": true,
+                            "query": true
+                        ],
+                        predicateOperator: .deepEquals,
+                        caseSensitive: true,
+                        except: "!$",
+                        ignore: ["query": "startDate"]
+                    ),
+                    .matches(
+                        fields: ["body": true],
+                        jsonPath: JSONPath(selector: "$..number")
+                    ),
+                    .matches(
+                        fields: ["body": true],
+                        xPath: XPath(selector: "//number")
+                    ),
+                    .inject("    function (config) {\n        const predicate = {\n            exists: {\n                headers: {\n                    \'X-Transaction-Id\': false\n                }\n            }\n        };\n        if (config.request.headers[\'X-Transaction-Id\']) {\n            config.logger.debug(\'Requiring X-Transaction-Id header to exist in predicate\');\n            predicate.exists.headers[\'X-Transaction-Id\'] = true;\n        }\n        return [predicate];\n    }")
+                ]
+            ),
+            predicates: []
+        ),
+        Stub(
+            response: Is(
+                statusCode: 200,
+                body: .text("Hello world")
+            ),
+            predicates: []
+        ),
+        Stub(
+            response: Is(statusCode: 404),
+            predicate: .equals(Request(path: "/404"))
+        ),
+        Stub(
+            responses: [
+                Is(statusCode: 404),
+                Is(
+                    statusCode: 200,
+                    body: .text("Hello world")
+                )
+            ],
+            predicate: .equals(Request(path: "/404-to-200"))
+        ),
+        Stub(
+            responses: [
+                Is(
+                    statusCode: 200,
+                    body: .text("Hello world")
+                ),
+                Is(
+                    statusCode: 200,
+                    headers: ["Content-Type": "text/html"],
+                    body: .text("<html><body><h1>Who needs HTML?</h1></html>")
+                ),
+                Is(
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"],
+                    body: .json([
+                        "bikeId": 123.0,
+                        "name": "Turbo Bike 4000"
+                    ])
+                ),
+                Is(
+                    statusCode: 200,
+                    body: .data(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAABaADAAQAAAABAAAABQAAAAB/qhzxAAAAKUlEQVQIHWP8//8/AwMjI5CAgv//wTyEAFScCaYAmcYhCDQDWRUDkA8AEGsMAtJaFngAAAAASUVORK5CYII=")!)
+                ),
+                Is(statusCode: 404),
+                Proxy(
+                    to: "https://www.somesite.com:3000",
+                    mode: .proxyAlways
+                ),
+                Fault.connectionResetByPeer,
+                Inject("(config) => { return { \"body\": \"hello world\" }; }")
+            ],
+            predicates: [
+                .equals(Request(
+                    method: .put,
+                    path: "/test-is-200",
+                    query: ["key": [
+                        "first",
+                        "second"
+                    ]],
+                    headers: ["foo": "bar"],
+                    data: ["baz"]
+                )),
+                .deepEquals(Request(query: ["key": [
+                    "first",
+                    "second"
+                ]])),
+                .contains(Request(data: "AgM=")),
+                .startsWith(Request(data: "first")),
+                .endsWith(Request(data: "last")),
+                .matches(Request(data: "^first")),
+                .exists(Request(query: [
+                    "q": true,
+                    "search": false
+                ])),
+                .not(.equals(Request(
+                    method: .put,
+                    path: "/test-is-200",
+                    query: ["key": [
+                        "first",
+                        "second"
+                    ]],
+                    headers: ["foo": "bar"],
+                    data: ["baz"]
+                ))),
+                .or([
+                    .equals(Request(
+                        method: .put,
+                        path: "/test-is-200",
+                        query: ["key": [
+                            "first",
+                            "second"
+                        ]],
+                        headers: ["foo": "bar"],
+                        data: ["baz"]
+                    )),
+                    .contains(Request(data: "AgM="))
+                ]),
+                .and([
+                    .equals(Request(
+                        method: .put,
+                        path: "/test-is-200",
+                        query: ["key": [
+                            "first",
+                            "second"
+                        ]],
+                        headers: ["foo": "bar"],
+                        data: ["baz"]
+                    )),
+                    .deepEquals(Request(query: ["key": [
+                        "first",
+                        "second"
+                    ]]))
+                ]),
+                .inject("(config) => { return config.request.headers[\'Authorization\'] == \'Bearer <my-token>\'; }"),
+                .equals(
+                    Request(path: "/with-parameters"),
+                    PredicateParameters(
+                        caseSensitive: true,
+                        except: "^The ",
+                        xPath: XPath(
+                            selector: "//a:title",
+                            namespace: ["a": "http://example.com/book"]
+                        ),
+                        jsonPath: JSONPath(selector: "$..title")
+                    )
+                )
+            ]
+        )
+    ]
+}
+// swiftlint:enable line_length force_unwrapping


### PR DESCRIPTION
Adding an extension around the generated stubs. 
- Scopes the stubs to the test
- Renamed the property name so that multiple tests can generate multiple arrays of stubs without name collisions. 

Generated code: 

Old 

```
static let stubsForAll: [Stub] = [
    Stub(
        response: Is(
            statusCode: 200,
            body: .text("Hello world")
        ),
        predicate: .equals(Request(path: "/text-200"))
    )
    ...
]
```

New 

```
extension ImposterTests {
    static let testWriteToDiskStubsAll: [Stub] = [
        Stub(
            response: Is(
                statusCode: 200,
                body: .text("Hello world")
            ),
            predicate: .equals(Request(path: "/text-200"))
        ),
        ...
    ]
}
```