### PR TITLE
Correct SPM version on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dependency in `Package.swift`:
 dependencies: [
   .package(
     url: "https://github.com/MountebankSwift/MountebankSwift",
-    from: "1.0.0"
+    from: "0.0.0"
   ),
 ]
 ```


### PR DESCRIPTION
Nice library, found it from cocoaheads 🚀 
A quick fix:
v1.0.0...v2.0.0 does not exist yet resulting in error when adding into you project.
This PR resolves this.